### PR TITLE
feat: create baseEntity

### DIFF
--- a/src/main/java/com/pawstime/pawstime/PawstimeApplication.java
+++ b/src/main/java/com/pawstime/pawstime/PawstimeApplication.java
@@ -2,7 +2,9 @@ package com.pawstime.pawstime;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class PawstimeApplication {
 

--- a/src/main/java/com/pawstime/pawstime/global/entity/BaseEntity.java
+++ b/src/main/java/com/pawstime/pawstime/global/entity/BaseEntity.java
@@ -1,0 +1,27 @@
+package com.pawstime.pawstime.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+  @CreatedDate
+  @Column(name = "created_at")
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  @Column(name = "updated_at")
+  private LocalDateTime updatedAt;
+
+  @Column(name = "is_delete")
+  private boolean isDelete = false;
+}


### PR DESCRIPTION
## 📝 설명 (Description)
BaseEntity 클래스를 생성하여 공통적인 엔티티 속성을 관리하도록 변경했습니다.
이를 통해 코드 중복을 줄이고 엔티티들의 일관성을 유지할 수 있습니다.

--- 

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:
- [x] 변경사항 1 : BaseEntity 클래스 생성 (`createdAt`, `updatedAt`, `isDelete` 필드)
- [x] 변경사항 2 : JPA Auditing을 사용하기 위해 @EnableJpaAuditing 어노테이션을 메인 애플리케이션에 추가
---

## 📌 참고 사항 (Additional Notes)

