### PR TITLE
Feat: create board

### DIFF
--- a/src/main/java/com/pawstime/pawstime/PawstimeApplication.java
+++ b/src/main/java/com/pawstime/pawstime/PawstimeApplication.java
@@ -2,7 +2,9 @@ package com.pawstime.pawstime;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class PawstimeApplication {
 

--- a/src/main/java/com/pawstime/pawstime/domain/board/controller/BoardController.java
+++ b/src/main/java/com/pawstime/pawstime/domain/board/controller/BoardController.java
@@ -1,0 +1,35 @@
+package com.pawstime.pawstime.domain.board.controller;
+
+import com.pawstime.pawstime.domain.board.dto.req.CreateBoardReqDto;
+import com.pawstime.pawstime.domain.board.facade.BoardFacade;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@Tag(name = "Board", description = "게사판 API")
+@RestController
+@RequestMapping("/board")
+@RequiredArgsConstructor
+public class BoardController {
+
+  private final BoardFacade boardFacade;
+
+  @Operation(summary = "게시판 생성", description = "새로운 게시판을 생성할 수 있습니다.")
+  @PostMapping("/boards")
+  public ResponseEntity<String> createBoard(@RequestBody CreateBoardReqDto req) {
+    try {
+      boardFacade.createBoard(req);
+
+      return ResponseEntity.ok().body("게시판 생성이 완료되었습니다.");
+    } catch (Exception e) {
+      return ResponseEntity.badRequest().body("게시판 생성 중 오류가 발생하였습니다.");
+    }
+  }
+}

--- a/src/main/java/com/pawstime/pawstime/domain/board/controller/BoardController.java
+++ b/src/main/java/com/pawstime/pawstime/domain/board/controller/BoardController.java
@@ -29,7 +29,7 @@ public class BoardController {
 
       return ResponseEntity.ok().body("게시판 생성이 완료되었습니다.");
     } catch (Exception e) {
-      return ResponseEntity.badRequest().body("게시판 생성 중 오류가 발생하였습니다.");
+      return ResponseEntity.badRequest().body("게시판 생성 중 오류가 발생하였습니다 : " + e.getMessage());
     }
   }
 }

--- a/src/main/java/com/pawstime/pawstime/domain/board/dto/req/CreateBoardReqDto.java
+++ b/src/main/java/com/pawstime/pawstime/domain/board/dto/req/CreateBoardReqDto.java
@@ -1,0 +1,20 @@
+package com.pawstime.pawstime.domain.board.dto.req;
+
+import com.pawstime.pawstime.domain.board.entity.Board;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record CreateBoardReqDto(
+    @Schema(description = "게시판 제목", example = "일상 게시판")
+    String title,
+
+    @Schema(description = "게시판 설명", example = "일상 게시판을 활용하여 반려동물과의 일상을 기록해보세요.")
+    String description
+) {
+
+  public Board of() {
+    return Board.builder()
+        .title(this.title)
+        .description(this.description)
+        .build();
+  }
+}

--- a/src/main/java/com/pawstime/pawstime/domain/board/entity/Board.java
+++ b/src/main/java/com/pawstime/pawstime/domain/board/entity/Board.java
@@ -25,7 +25,7 @@ public class Board extends BaseEntity {
   @Column(name = "board_id")
   private Long boardId;
 
-  @Column(unique = true, nullable = false)
+  @Column(nullable = false)
   private String title;
 
   private String description;

--- a/src/main/java/com/pawstime/pawstime/domain/board/entity/Board.java
+++ b/src/main/java/com/pawstime/pawstime/domain/board/entity/Board.java
@@ -1,5 +1,32 @@
 package com.pawstime.pawstime.domain.board.entity;
 
-public class Board {
+import com.pawstime.pawstime.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Getter
+@Builder
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "board")
+public class Board extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "board_id")
+  private Long boardId;
+
+  @Column(unique = true, nullable = false)
+  private String title;
+
+  private String description;
 }

--- a/src/main/java/com/pawstime/pawstime/domain/board/entity/repository/BoardRepository.java
+++ b/src/main/java/com/pawstime/pawstime/domain/board/entity/repository/BoardRepository.java
@@ -2,9 +2,12 @@ package com.pawstime.pawstime.domain.board.entity.repository;
 
 import com.pawstime.pawstime.domain.board.entity.Board;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface BoardRepository extends JpaRepository<Board, Long> {
 
+  @Query("SELECT b FROM Board b WHERE b.title = :title and b.isDelete = false")
+  Board findByTitleQuery(String title);
 }

--- a/src/main/java/com/pawstime/pawstime/domain/board/entity/repository/BoardRepository.java
+++ b/src/main/java/com/pawstime/pawstime/domain/board/entity/repository/BoardRepository.java
@@ -1,0 +1,10 @@
+package com.pawstime.pawstime.domain.board.entity.repository;
+
+import com.pawstime.pawstime.domain.board.entity.Board;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BoardRepository extends JpaRepository<Board, Long> {
+
+}

--- a/src/main/java/com/pawstime/pawstime/domain/board/facade/BoardFacade.java
+++ b/src/main/java/com/pawstime/pawstime/domain/board/facade/BoardFacade.java
@@ -1,0 +1,21 @@
+package com.pawstime.pawstime.domain.board.facade;
+
+import com.pawstime.pawstime.domain.board.dto.req.CreateBoardReqDto;
+import com.pawstime.pawstime.domain.board.service.CreateBoardService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Transactional
+@Component
+@RequiredArgsConstructor
+public class BoardFacade {
+
+  private final CreateBoardService createBoardService;
+
+  public void createBoard(CreateBoardReqDto req) {
+    createBoardService.createBoard(req.of());
+  }
+}

--- a/src/main/java/com/pawstime/pawstime/domain/board/facade/BoardFacade.java
+++ b/src/main/java/com/pawstime/pawstime/domain/board/facade/BoardFacade.java
@@ -1,7 +1,9 @@
 package com.pawstime.pawstime.domain.board.facade;
 
 import com.pawstime.pawstime.domain.board.dto.req.CreateBoardReqDto;
+import com.pawstime.pawstime.domain.board.entity.Board;
 import com.pawstime.pawstime.domain.board.service.CreateBoardService;
+import com.pawstime.pawstime.domain.board.service.ReadBoardService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -13,9 +15,16 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class BoardFacade {
 
+  private final ReadBoardService readBoardService;
   private final CreateBoardService createBoardService;
 
   public void createBoard(CreateBoardReqDto req) {
+    Board board = readBoardService.findByTitle(req.title());
+
+    if (board != null) {
+      throw new RuntimeException("이미 존재하는 게시판입니다.");
+    }
+
     createBoardService.createBoard(req.of());
   }
 }

--- a/src/main/java/com/pawstime/pawstime/domain/board/service/CreateBoardService.java
+++ b/src/main/java/com/pawstime/pawstime/domain/board/service/CreateBoardService.java
@@ -1,0 +1,19 @@
+package com.pawstime.pawstime.domain.board.service;
+
+import com.pawstime.pawstime.domain.board.dto.req.CreateBoardReqDto;
+import com.pawstime.pawstime.domain.board.entity.Board;
+import com.pawstime.pawstime.domain.board.entity.repository.BoardRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CreateBoardService {
+
+  private final BoardRepository boardRepository;
+
+  public void createBoard(Board board) {
+    boardRepository.save(board);
+  }
+}

--- a/src/main/java/com/pawstime/pawstime/domain/board/service/ReadBoardService.java
+++ b/src/main/java/com/pawstime/pawstime/domain/board/service/ReadBoardService.java
@@ -1,0 +1,17 @@
+package com.pawstime.pawstime.domain.board.service;
+
+import com.pawstime.pawstime.domain.board.entity.Board;
+import com.pawstime.pawstime.domain.board.entity.repository.BoardRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ReadBoardService {
+
+  private final BoardRepository boardRepository;
+
+  public Board findByTitle(String title) {
+    return boardRepository.findByTitleQuery(title);
+  }
+}

--- a/src/main/java/com/pawstime/pawstime/global/entity/BaseEntity.java
+++ b/src/main/java/com/pawstime/pawstime/global/entity/BaseEntity.java
@@ -1,0 +1,27 @@
+package com.pawstime.pawstime.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+  @CreatedDate
+  @Column(name = "created_at")
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  @Column(name = "updated_at")
+  private LocalDateTime updatedAt;
+
+  @Column(name = "is_delete")
+  private boolean isDelete = false;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,7 +8,7 @@ spring:
     name: basic
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
## 📝 설명 (Description)
게시판 생성 기능을 구현하였습니다.

--- 

## 🔄 변경 사항 (Changes)
- [x] 변경사항 1 : CreateBoardReqDto (게시판 생성 요청 시 제목과 설명을 입력받습니다)
- [x] 변경사항 2 : CreateBoardService (BoardRepository.save()를 통해 데이터베이스에 저장합니다)
- [x] 변경사항 3 : @Schema 어노테이션으로 설명 및 예시 추가하여 Swagger에서 테스트시 쉽게 알 수 있도록 하였습니다
- [x] 변경사항 4 : 게시판 제목을 엔티티에서 바로 unique로 설정하는 것이 아닌 readBoardService를 통해 제목 중복 여부를 조회합니다. Soft Delete를 고려하여 is_delete = true인 경우에는 동일한 제목으로 게시판 생성이 가능하고, is_delete = false 상태에서만 제목의 중복을 제한합니다.

---

## 📌 참고 사항 (Additional Notes)
추후 유저 기능이 완료되면 관리자만 게시판 생성이 가능하도록 수정할 계획입니다.
