### PR TITLE
feat:create entity userrole 

### DIFF
--- a/src/main/java/com/pawstime/pawstime/domain/Role/entity/Role.java
+++ b/src/main/java/com/pawstime/pawstime/domain/Role/entity/Role.java
@@ -1,10 +1,15 @@
 package com.pawstime.pawstime.domain.Role.entity;
 
+import com.pawstime.pawstime.domain.userrole.entity.UserRole;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.util.HashSet;
+import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -23,6 +28,9 @@ public class Role {
 
   @Column(nullable = false)
   private String roleName;  // 역할 이름을 저장하는 필드
+
+  @OneToMany(mappedBy = "role", cascade = CascadeType.ALL, orphanRemoval = true)
+  private Set<UserRole> userRoles = new HashSet<>();
 
   public String getRoleName(){
     return this.getRoleName();

--- a/src/main/java/com/pawstime/pawstime/domain/Role/entity/repository/RoleRepository.java
+++ b/src/main/java/com/pawstime/pawstime/domain/Role/entity/repository/RoleRepository.java
@@ -1,0 +1,11 @@
+package com.pawstime.pawstime.domain.Role.entity.repository;
+
+import com.pawstime.pawstime.domain.Role.entity.Role;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoleRepository extends JpaRepository<Role, Long> {
+
+  Optional<Role> findByRoleName(String roleName);
+
+}

--- a/src/main/java/com/pawstime/pawstime/domain/user/entity/User.java
+++ b/src/main/java/com/pawstime/pawstime/domain/user/entity/User.java
@@ -1,14 +1,13 @@
 package com.pawstime.pawstime.domain.user.entity;
 
-import com.pawstime.pawstime.domain.Role.entity.Role;
+import com.pawstime.pawstime.domain.userrole.entity.UserRole;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.JoinTable;
-import jakarta.persistence.ManyToMany;
+import jakarta.persistence.OneToMany;
 import java.util.HashSet;
 import java.util.Set;
 import lombok.AllArgsConstructor;
@@ -35,13 +34,7 @@ public class User {
 
   private String password;
 
-  @ManyToMany
-  @JoinTable(
-      name = "user_roles", // 중간 테이블 이름
-      joinColumns = @JoinColumn(name = "user_id"), // User 테이블의 외래키
-      inverseJoinColumns = @JoinColumn(name = "role_id") // Role 테이블의 외래키
-  )
-  private Set<Role> roles = new HashSet<>();
-
+  @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+  private Set<UserRole> userRoles = new HashSet<>();
 
 }

--- a/src/main/java/com/pawstime/pawstime/domain/user/entity/repository/UserRepository.java
+++ b/src/main/java/com/pawstime/pawstime/domain/user/entity/repository/UserRepository.java
@@ -6,4 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface UserRepository extends JpaRepository<User, Long> {
 
   User findByEmail(String email);
+  boolean existsByEmail(String email);
 }

--- a/src/main/java/com/pawstime/pawstime/domain/user/facade/UserFacade.java
+++ b/src/main/java/com/pawstime/pawstime/domain/user/facade/UserFacade.java
@@ -1,0 +1,63 @@
+package com.pawstime.pawstime.domain.user.facade;
+
+import com.pawstime.pawstime.domain.Role.entity.Role;
+import com.pawstime.pawstime.domain.Role.entity.repository.RoleRepository;
+import com.pawstime.pawstime.domain.user.entity.User;
+import com.pawstime.pawstime.domain.user.service.create.CreateUserService;
+import com.pawstime.pawstime.domain.user.service.dto.CustomUserInfoDto;
+import com.pawstime.pawstime.domain.user.service.read.ReadUserService;
+import com.pawstime.pawstime.global.jwt.util.JwtUtil;
+import com.pawstime.pawstime.web.api.user.dto.request.LoginUserRequestDto;
+import com.pawstime.pawstime.web.api.user.dto.request.UserCreateRequestDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserFacade {
+
+  private final CreateUserService createUserService;
+  private final ReadUserService readUserService;
+  private final PasswordEncoder encoder;
+  private final JwtUtil jwtUtil;
+  private final RoleRepository roleRepository;
+  @Transactional
+  public void createUser(@Valid UserCreateRequestDto dto) {
+
+    //1.이메일 중복 확인
+    if(readUserService.existsByEmail(dto.email())){
+      throw new BadCredentialsException("존재하는 이메일입니다.");
+    }
+    //역할 확인 및 변환
+    Role role = roleRepository.findByRoleName(dto.roleName())
+      .orElseThrow(() -> new IllegalArgumentException("잘못된 역할 이름입니다."));
+
+  // User 엔티티 생성
+    User user = dto.of(encoder.encode(dto.password()), role);
+
+    // User 및 UserRole 저장
+    createUserService.createUser(user, role);
+  }
+
+  public String login(LoginUserRequestDto dto) {
+    User user = readUserService.findUserByEmail(dto.email());
+
+    if (user == null) {
+      throw new UsernameNotFoundException("이메일이 존재하지 않습니다.");
+    }
+
+    if (!encoder.matches(dto.password(), user.getPassword())) {
+      throw new BadCredentialsException("비밀번호가 맞지 않습니다.");
+    }
+
+    CustomUserInfoDto customUserInfoDto = CustomUserInfoDto.of(user);
+    return jwtUtil.createAccessToken(customUserInfoDto);
+  }
+}

--- a/src/main/java/com/pawstime/pawstime/domain/user/service/create/CreateUserService.java
+++ b/src/main/java/com/pawstime/pawstime/domain/user/service/create/CreateUserService.java
@@ -1,0 +1,29 @@
+package com.pawstime.pawstime.domain.user.service.create;
+
+import com.pawstime.pawstime.domain.Role.entity.Role;
+import com.pawstime.pawstime.domain.user.entity.User;
+import com.pawstime.pawstime.domain.user.entity.repository.UserRepository;
+import com.pawstime.pawstime.domain.userrole.entity.UserRole;
+import com.pawstime.pawstime.domain.userrole.entity.repository.UserRoleRepository;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CreateUserService {
+
+  private final UserRepository userRepository;
+  private final UserRoleRepository userRoleRepository;
+
+  public void createUser(User user, Role role){
+    //user 저장
+    userRepository.save(user);
+
+    //UserRole 생성 및 저장
+    UserRole userRole =  new UserRole(null, user, role, LocalDateTime.now());
+    userRoleRepository.save(userRole);
+  }
+}

--- a/src/main/java/com/pawstime/pawstime/domain/user/service/read/ReadUserService.java
+++ b/src/main/java/com/pawstime/pawstime/domain/user/service/read/ReadUserService.java
@@ -1,0 +1,21 @@
+package com.pawstime.pawstime.domain.user.service.read;
+
+import com.pawstime.pawstime.domain.user.entity.User;
+import com.pawstime.pawstime.domain.user.entity.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ReadUserService {
+
+  private final UserRepository userRepository;
+
+  public User findUserByEmail(String email){
+    return userRepository.findByEmail(email);
+  }
+
+  public boolean existsByEmail(String email){
+    return userRepository.existsByEmail(email);
+  }
+}

--- a/src/main/java/com/pawstime/pawstime/domain/userrole/entity/UserRole.java
+++ b/src/main/java/com/pawstime/pawstime/domain/userrole/entity/UserRole.java
@@ -1,0 +1,37 @@
+package com.pawstime.pawstime.domain.userrole.entity;
+
+import com.pawstime.pawstime.domain.Role.entity.Role;
+import com.pawstime.pawstime.domain.user.entity.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserRole {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+
+  @ManyToOne
+  @JoinColumn(name = "role_id", nullable = false)
+  private Role role;
+
+  private LocalDateTime assignedAt; // 역할 부여 날짜
+}

--- a/src/main/java/com/pawstime/pawstime/domain/userrole/entity/repository/UserRoleRepository.java
+++ b/src/main/java/com/pawstime/pawstime/domain/userrole/entity/repository/UserRoleRepository.java
@@ -1,0 +1,8 @@
+package com.pawstime.pawstime.domain.userrole.entity.repository;
+
+import com.pawstime.pawstime.domain.userrole.entity.UserRole;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRoleRepository extends JpaRepository<UserRole, Long> {
+
+}

--- a/src/main/java/com/pawstime/pawstime/global/config/security/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/pawstime/pawstime/global/config/security/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,40 @@
+package com.pawstime.pawstime.global.config.security.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pawstime.pawstime.global.dto.ErrorResponseDto;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@Slf4j(topic = "FORBIDDEN_EXCEPTION_HANDLER")
+@AllArgsConstructor
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+  private final ObjectMapper objectMapper;
+
+  @Override
+  public void handle(HttpServletRequest request, HttpServletResponse response,
+      AccessDeniedException accessDeniedException) throws IOException, ServletException {
+
+    log.error("No Authorities", accessDeniedException);
+
+    ErrorResponseDto errorResponseDto =
+        new ErrorResponseDto(
+            HttpStatus.FORBIDDEN, accessDeniedException.getMessage(), LocalDateTime.now());
+    String responseBody = objectMapper.writeValueAsString(errorResponseDto);
+    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    response.setStatus(HttpStatus.FORBIDDEN.value());
+    response.setCharacterEncoding("UTF-8");
+    response.getWriter().write(responseBody);
+  }
+}

--- a/src/main/java/com/pawstime/pawstime/global/config/security/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/pawstime/pawstime/global/config/security/handler/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,41 @@
+package com.pawstime.pawstime.global.config.security.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pawstime.pawstime.global.dto.ErrorResponseDto;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Slf4j(topic = "UNAUTHORIZATION_EXCEPTION_HANDLER")
+@AllArgsConstructor
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+  private final ObjectMapper objectMapper;
+
+
+  @Override
+  public void commence(HttpServletRequest request, HttpServletResponse response,
+      AuthenticationException authException) throws IOException, ServletException {
+
+    log.error("Not Authenticated Request", authException);
+
+    ErrorResponseDto errorResponseDto =
+        new ErrorResponseDto(HttpStatus.UNAUTHORIZED, authException.getMessage(), LocalDateTime.now());
+
+    String responseBody = objectMapper.writeValueAsString(errorResponseDto);
+    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    response.setStatus(HttpStatus.UNAUTHORIZED.value());
+    response.setCharacterEncoding("UTF-8");
+    response.getWriter().write(responseBody);
+  }
+}

--- a/src/main/java/com/pawstime/pawstime/global/config/security/user/service/CustomUserDetailsService.java
+++ b/src/main/java/com/pawstime/pawstime/global/config/security/user/service/CustomUserDetailsService.java
@@ -28,7 +28,6 @@ public class CustomUserDetailsService implements UserDetailsService {
     if (user == null) {
       throw new UsernameNotFoundException("존재하지 않는 유저입니다.");
     }
-
     CustomUserInfoDto customUserInfoDto = CustomUserInfoDto.of(user);
     return new CustomUserDetails(customUserInfoDto);
   }

--- a/src/main/java/com/pawstime/pawstime/global/dto/ErrorResponseDto.java
+++ b/src/main/java/com/pawstime/pawstime/global/dto/ErrorResponseDto.java
@@ -1,0 +1,12 @@
+package com.pawstime.pawstime.global.dto;
+
+import java.time.LocalDateTime;
+import org.springframework.http.HttpStatus;
+
+public record ErrorResponseDto(
+    HttpStatus status,
+    String message,
+    LocalDateTime errorDateTime
+) {
+
+}

--- a/src/main/java/com/pawstime/pawstime/web/api/user/UserApiController.java
+++ b/src/main/java/com/pawstime/pawstime/web/api/user/UserApiController.java
@@ -1,0 +1,43 @@
+package com.pawstime.pawstime.web.api.user;
+
+import com.pawstime.pawstime.domain.user.facade.UserFacade;
+import com.pawstime.pawstime.global.jwt.util.JwtUtil;
+import com.pawstime.pawstime.web.api.user.dto.request.LoginUserRequestDto;
+import com.pawstime.pawstime.web.api.user.dto.request.UserCreateRequestDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@Tag(name = "USER API", description = "유저 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class UserApiController {
+
+  private final UserFacade userFacade;
+  private final JwtUtil jwtUtil;
+
+
+  @Operation(summary = "회원 신규 가입")
+  @PostMapping("/user")
+  public ResponseEntity<?> createUser(@Valid @RequestBody UserCreateRequestDto dto) {
+    userFacade.createUser(dto);
+    return ResponseEntity.ok().build();
+  }
+
+  @Operation(summary = "로그인")
+  @PostMapping("/login")
+  public ResponseEntity<?> loginrUser(@Valid @RequestBody LoginUserRequestDto dto) {
+    String token = userFacade.login(dto);
+    return ResponseEntity.status(HttpStatus.OK).body(token);
+  }
+}

--- a/src/main/java/com/pawstime/pawstime/web/api/user/dto/request/LoginUserRequestDto.java
+++ b/src/main/java/com/pawstime/pawstime/web/api/user/dto/request/LoginUserRequestDto.java
@@ -1,0 +1,12 @@
+package com.pawstime.pawstime.web.api.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginUserRequestDto(
+    @NotBlank
+    String email,
+    @NotBlank
+    String password
+) {
+
+}

--- a/src/main/java/com/pawstime/pawstime/web/api/user/dto/request/UserCreateRequestDto.java
+++ b/src/main/java/com/pawstime/pawstime/web/api/user/dto/request/UserCreateRequestDto.java
@@ -1,0 +1,32 @@
+package com.pawstime.pawstime.web.api.user.dto.request;
+
+import com.pawstime.pawstime.domain.Role.entity.Role;
+import com.pawstime.pawstime.domain.user.entity.User;
+import com.pawstime.pawstime.domain.userrole.entity.UserRole;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
+
+
+public record UserCreateRequestDto(
+    @NotBlank
+    String email,
+    @NotBlank
+    @Pattern(regexp = "^(?=.*[A-Z])(?=.*[0-9])(?=.*[a-z])(?=.*[!@#$%^&*()\\-+=]).{8,}$")
+    String password,
+    @NotBlank
+    String nick,
+    String roleName // String role로 받되, of에서 Role객체로 변환함
+) {
+
+  public User of(String password, Role role) {
+    return User.builder()
+        .email(email)
+        .nick(nick)
+        .password(password)
+        .userRoles(new HashSet<>(Set.of(new UserRole(null, null, role, LocalDateTime.now())))) // UserRole 생성
+        .build();
+  }
+}


### PR DESCRIPTION
## 📝 설명 (Description)
간단하게 무엇을 변경했는지 설명해주세요. <br>


회원가입 시 사용자의 역할을 추가로 저장하는 기능을 구현했습니다. User와 Role을 매핑하고 이를 UserRole로 저장하는 로직을 추가하여, 역할 기반의 권한 관리 시스템을 위한 기초 작업을 진행했습니다.

--- 

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:
1. UserCreateRequestDto에 roleName 필드 추가: 사용자 요청에 역할을 포함시켜, 역할에 대한 정보를 받아올 수 있도록 변경했습니다.
2. UserFacade에서 Role 조회 및 UserRole 생성: 사용자 생성 시 역할을 확인하고, UserRole을 생성하여 User와 Role을 연결하는 로직을 추가했습니다.
3. CreateUserService에서 UserRole 저장: User와 UserRole을 각각 저장하는 로직을 CreateUserService에 추가했습니다.
 RoleRepository에서 역할 이름으로 Role 조회: Role을 이름으로 조회하여 매핑하는 로직을 추가했습니다.

---

## 📌 참고 사항 (Additional Notes)

1. RoleRepository의 findByRoleName 메서드는 Optional<Role>을 반환하며, 역할 이름이 잘못된 경우 예외를 발생시키므로 주의가 필요합니다.
2. UserRole 생성 시, User와 Role의 관계를 명시적으로 저장하는 방식으로 구현되었습니다.
3. 역할 이름이 유효하지 않을 경우 예외 처리 로직이 추가되었으므로, 이를 처리할 수 있는 방식으로 사용자에게 알림을 제공해야 합니다.
