### PR TITLE
feat: board 목록 조회 기능

### DIFF
--- a/src/main/java/com/pawstime/pawstime/domain/board/controller/BoardController.java
+++ b/src/main/java/com/pawstime/pawstime/domain/board/controller/BoardController.java
@@ -1,9 +1,11 @@
 package com.pawstime.pawstime.domain.board.controller;
 
 import com.pawstime.pawstime.domain.board.dto.req.CreateBoardReqDto;
+import com.pawstime.pawstime.domain.board.dto.resp.GetBoardRespDto;
 import com.pawstime.pawstime.domain.board.facade.BoardFacade;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -12,6 +14,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
@@ -38,7 +41,18 @@ public class BoardController {
   @Operation(summary = "게시판 상세 조회",
       description = "board_id를 입력하면 title, description을 조회할 수 있습니다.")
   @GetMapping("/{boardId}")
-  public ResponseEntity<?> getBoard(@PathVariable Long boardId) {
+  public ResponseEntity<GetBoardRespDto> getBoard(@PathVariable Long boardId) {
     return ResponseEntity.ok().body(boardFacade.getBoard(boardId));
+  }
+
+  @Operation(summary = "게시판 목록 조회", description = "생성되어있는 모든 게시판을 조회합니다.")
+  @GetMapping("/list")
+  public ResponseEntity<List<GetBoardRespDto>> getBoardList(
+      @RequestParam(defaultValue = "0") int pageNo,
+      @RequestParam(defaultValue = "10") int pageSize,
+      @RequestParam(defaultValue = "createdAt") String sortBy,
+      @RequestParam(defaultValue = "DESC") String direction
+  ) {
+    return ResponseEntity.ok().body(boardFacade.getBoardList(pageNo, pageSize, sortBy, direction).getContent());
   }
 }

--- a/src/main/java/com/pawstime/pawstime/domain/board/entity/repository/BoardRepository.java
+++ b/src/main/java/com/pawstime/pawstime/domain/board/entity/repository/BoardRepository.java
@@ -1,6 +1,9 @@
 package com.pawstime.pawstime.domain.board.entity.repository;
 
 import com.pawstime.pawstime.domain.board.entity.Board;
+import jakarta.annotation.Nonnull;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -10,4 +13,5 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
 
   @Query("SELECT b FROM Board b WHERE b.title = :title and b.isDelete = false")
   Board findByTitleQuery(String title);
+
 }

--- a/src/main/java/com/pawstime/pawstime/domain/board/facade/BoardFacade.java
+++ b/src/main/java/com/pawstime/pawstime/domain/board/facade/BoardFacade.java
@@ -5,8 +5,13 @@ import com.pawstime.pawstime.domain.board.dto.resp.GetBoardRespDto;
 import com.pawstime.pawstime.domain.board.entity.Board;
 import com.pawstime.pawstime.domain.board.service.CreateBoardService;
 import com.pawstime.pawstime.domain.board.service.ReadBoardService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -37,5 +42,12 @@ public class BoardFacade {
     }
 
     return GetBoardRespDto.from(board);
+  }
+
+  public Page<GetBoardRespDto> getBoardList(int pageNo, int pageSize, String sortBy, String direction) {
+
+    Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by(Sort.Direction.fromString(direction), sortBy));
+
+    return readBoardService.getBoardList(pageable).map(GetBoardRespDto::from);
   }
 }

--- a/src/main/java/com/pawstime/pawstime/domain/board/service/ReadBoardService.java
+++ b/src/main/java/com/pawstime/pawstime/domain/board/service/ReadBoardService.java
@@ -3,7 +3,10 @@ package com.pawstime.pawstime.domain.board.service;
 import com.pawstime.pawstime.domain.board.dto.resp.GetBoardRespDto;
 import com.pawstime.pawstime.domain.board.entity.Board;
 import com.pawstime.pawstime.domain.board.entity.repository.BoardRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -18,5 +21,9 @@ public class ReadBoardService {
 
   public Board findById(Long boardId) {
     return boardRepository.findById(boardId).orElse(null);
+  }
+
+  public Page<Board> getBoardList(Pageable pageable) {
+    return boardRepository.findAll(pageable);
   }
 }

--- a/src/main/java/com/pawstime/pawstime/global/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/pawstime/pawstime/global/config/swagger/SwaggerConfig.java
@@ -17,6 +17,10 @@ import org.springframework.context.annotation.Configuration;
         @io.swagger.v3.oas.annotations.servers.Server(
             url = "http://localhost:8080/",
             description = "local test"
+        ),
+        @io.swagger.v3.oas.annotations.servers.Server(
+            url = "http://43.200.46.13:8080/",
+            description = "dev test"
         )
     }
 )

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -8,7 +8,7 @@ spring:
     name: basic
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     database: mysql
     show-sql: true
     properties:


### PR DESCRIPTION
## 📝 설명 (Description)
페이지네이션 기능과 정렬 기능을 이용한 게시판 목록 조회 기능을 구현하였습니다.

--- 

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:
- [x] 변경사항 1 : 페이지네이션, 정렬 기능 추가 - defaultValue를 설정하여 기본 값을 제공하였고, 필요에 따라 클라이언트는 페이지 번호, 페이지 크기, 정렬 기준 및 정렬 방향의 값을 수정하여 요청할 수 있습니다.

---

## 📌 참고 사항 (Additional Notes)
페이지 번호(pageNo)는 0부터 시작합니다. (0이 첫번째 페이지)
