### PR TITLE
feat: deleteBoard를 이용해 게시판 논리 삭제 기능구현

### DIFF
--- a/src/main/java/com/pawstime/pawstime/domain/board/controller/BoardController.java
+++ b/src/main/java/com/pawstime/pawstime/domain/board/controller/BoardController.java
@@ -12,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -54,5 +55,17 @@ public class BoardController {
       @RequestParam(defaultValue = "DESC") String direction
   ) {
     return ResponseEntity.ok().body(boardFacade.getBoardList(pageNo, pageSize, sortBy, direction).getContent());
+  }
+
+  @Operation(summary = "게시판 삭제", description = "선택한 게시판을 삭제합니다.")
+  @PutMapping("/delete/{boardId}")
+  public ResponseEntity<String> deleteBoard(@PathVariable Long boardId) {
+    try {
+      boardFacade.deleteBoard(boardId);
+
+      return ResponseEntity.ok().body("게시판이 삭제되었습니다.");
+    } catch (Exception e) {
+      return ResponseEntity.badRequest().body("게시판 삭제 중 오류가 발생하였습니다 : " + e.getMessage());
+    }
   }
 }

--- a/src/main/java/com/pawstime/pawstime/domain/board/entity/Board.java
+++ b/src/main/java/com/pawstime/pawstime/domain/board/entity/Board.java
@@ -29,4 +29,5 @@ public class Board extends BaseEntity {
   private String title;
 
   private String description;
+
 }

--- a/src/main/java/com/pawstime/pawstime/domain/board/facade/BoardFacade.java
+++ b/src/main/java/com/pawstime/pawstime/domain/board/facade/BoardFacade.java
@@ -50,4 +50,18 @@ public class BoardFacade {
 
     return readBoardService.getBoardList(pageable).map(GetBoardRespDto::from);
   }
+
+  public void deleteBoard(Long boardId) {
+    Board board = readBoardService.findById(boardId);
+
+    if (board == null) {
+      throw new RuntimeException("해당 ID의 게시판은 존재하지 않습니다.");
+    }
+    if (board.isDelete()) {
+      throw new RuntimeException("이미 삭제된 게시판입니다.");
+    }
+
+    board.softDelete();
+    createBoardService.createBoard(board);
+  }
 }

--- a/src/main/java/com/pawstime/pawstime/global/entity/BaseEntity.java
+++ b/src/main/java/com/pawstime/pawstime/global/entity/BaseEntity.java
@@ -24,4 +24,8 @@ public abstract class BaseEntity {
 
   @Column(name = "is_delete")
   private boolean isDelete = false;
+
+  public void softDelete() {
+    isDelete = true;
+  }
 }


### PR DESCRIPTION
## 📝 설명 (Description)
게시판 논리 삭제 기능을 구현했습니다. 
softDelete를 통해 데이터는 삭제되지 않고 상태만 변경되도록 처리했습니다.

--- 

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:
- [x] 변경사항 1 : 게시판 삭제요청 처리
게시판 ID를 입력받아 findById 메서드로 해당 게시판 데이터를 조회합니다.
예외 처리: 존재하지 않는 게시판이거나 이미 삭제된 게시판에 대해 예외를 발생시킵니다.
조회된 게시판이 삭제되지 않은 상태라면 softDelete 메서드를 호출해 논리 삭제 상태로 변경합니다.

---

## 📌 참고 사항 (Additional Notes)
실제 데이터가 삭제되는 것이 아니라 isDelete필드의 값만 false -> true로 변경하는 것이므로 @putmapping을 사용하였습니다.
별도의 의존성 추가나 설정 변경은 없습니다.
