### PR TITLE
feat:delete post

### DIFF
--- a/src/main/java/com/pawstime/pawstime/domain/post/controller/PostController.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/controller/PostController.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -65,6 +66,20 @@ public class PostController {
       } catch (Exception e) {
         return ResponseEntity.badRequest().body("게시글 수정 중 오류가 발생했습니다. " + e.getMessage());
       }
+    }
+  }
+  @Operation(summary = "게시글 삭제", description = "게시글을 삭제할 수 있습니다.")
+  @DeleteMapping("/posts/{postId}")
+  public ResponseEntity<String> deletePost(@PathVariable Long postId) {
+    try {
+      postFacade.deletePost(postId);
+      return ResponseEntity.ok("게시글 삭제가 완료되었습니다.");
+    } catch (IllegalArgumentException e) {
+      // 이미 삭제된 게시글인 경우
+      return ResponseEntity.badRequest().body("삭제할 수 없는 게시글입니다: " + e.getMessage());
+    } catch (Exception e) {
+      // 기타 예외 처리
+      return ResponseEntity.badRequest().body("게시글 삭제 중 오류가 발생했습니다. " + e.getMessage());
     }
   }
 }

--- a/src/main/java/com/pawstime/pawstime/domain/post/dto/req/CreatePostReqDto.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/dto/req/CreatePostReqDto.java
@@ -3,22 +3,24 @@ package com.pawstime.pawstime.domain.post.dto.req;
 import com.pawstime.pawstime.domain.board.entity.Board;
 import com.pawstime.pawstime.domain.post.entity.Post;
 import com.pawstime.pawstime.domain.post.entity.Post.PostCategory;
-import com.pawstime.pawstime.domain.user.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 
 public record CreatePostReqDto(
+    @Schema(description = "게시글 제목", example = "우리 집 구리 보러오세요")
     @NotBlank(message = "제목은 필수 입력값입니다.")
     @Size(min = 5, max = 20, message = "제목은 5자 이상, 20자 이하로 작성해야 합니다.")
     String title,           // 제목
+    @Schema(description = "게시글 내용", example = "일상 내용")
     @NotBlank(message = "내용은 필수 입력값입니다.")
     @Size(min = 5, message = "내용은 최소 5자 이상이어야 합니다.")
     String content,         // 내용
     //Long userId,            // 작성자 ID
     Long boardId,           // 게시판 ID
-    @NotNull(message = "카테고리는 필수 입력값입니다.")
+    @NotNull(message = "카테고리는 필수 입력 값입니다.")
     PostCategory category,  // 카테고리
     int likesCount          //좋아요 수
 

--- a/src/main/java/com/pawstime/pawstime/domain/post/dto/req/UpdatePostReqDto.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/dto/req/UpdatePostReqDto.java
@@ -1,12 +1,15 @@
 package com.pawstime.pawstime.domain.post.dto.req;
 
 import com.pawstime.pawstime.domain.post.entity.Post.PostCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record UpdatePostReqDto(
+    @Schema(description = "게시글 제목", example = "우리 집 구리 보러오세요")
     @NotBlank(message = "제목은 비어 있을 수 없습니다.")
     String title,
+    @Schema(description = "게시글 내용", example = "일상 내용")
     @NotBlank(message = "내용은 비어 있을 수 없습니다.")
     String content,
     @NotNull(message = "카테고리는 반드시 지정해야 합니다.")

--- a/src/main/java/com/pawstime/pawstime/domain/post/entity/Post.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/entity/Post.java
@@ -1,7 +1,6 @@
 package com.pawstime.pawstime.domain.post.entity;
 
 import com.pawstime.pawstime.domain.board.entity.Board;
-import com.pawstime.pawstime.domain.user.entity.User;
 import com.pawstime.pawstime.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -65,5 +64,7 @@ public class Post extends BaseEntity {
   public void increaseViews() {
     this.views += 1;
   }
+
+
 
 }

--- a/src/main/java/com/pawstime/pawstime/domain/post/facade/PostFacade.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/facade/PostFacade.java
@@ -5,6 +5,7 @@ import com.pawstime.pawstime.domain.post.dto.req.CreatePostReqDto;
 import com.pawstime.pawstime.domain.post.dto.req.UpdatePostReqDto;
 import com.pawstime.pawstime.domain.post.entity.Post;
 import com.pawstime.pawstime.domain.post.service.CreatePostService;
+import com.pawstime.pawstime.domain.post.service.DeletePostService;
 import com.pawstime.pawstime.domain.post.service.ReadPostService;
 import com.pawstime.pawstime.domain.post.service.UpdatePostService;
 import com.pawstime.pawstime.domain.user.entity.User;
@@ -18,11 +19,13 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 @RequiredArgsConstructor
 public class PostFacade {
+
   private final ReadPostService readPostService;
   private final CreatePostService createPostService;
   private final UpdatePostService updatePostService;
+  private final DeletePostService deletePostService;
 
-  public void createPost(CreatePostReqDto req){
+  public void createPost(CreatePostReqDto req) {
 
     /*
     User user = readPostService.findUserById(req.userId());
@@ -31,25 +34,30 @@ public class PostFacade {
     }
 */
     Board board = readPostService.findBoardById(req.boardId());
-    if (board == null){
+    if (board == null) {
       throw new RuntimeException("해당 Board ID는 존재하지 않습니다.");
     }
 
     //DTO를 엔티티로 변환
-    Post post = req.toEntity( board);
+    Post post = req.toEntity(board);
     createPostService.createPost(post);
   }
 
   //게시글 수정
-  public void updatePost(Long postId, UpdatePostReqDto req){
+  public void updatePost(Long postId, UpdatePostReqDto req) {
     Post existingPost = readPostService.findById(postId);
 
-    if(existingPost == null){
+    if (existingPost == null) {
       throw new RuntimeException("해당 id의 게시글은 존재하지 않습니다.");
     }
 
     //수정 서비스 호출
     updatePostService.updatePost(existingPost, req);
+  }
+
+  public void deletePost(Long postId) {
+
+    deletePostService.deletePost(postId);
   }
 
 

--- a/src/main/java/com/pawstime/pawstime/domain/post/service/DeletePostService.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/service/DeletePostService.java
@@ -1,0 +1,33 @@
+package com.pawstime.pawstime.domain.post.service;
+
+import com.pawstime.pawstime.domain.post.entity.Post;
+import com.pawstime.pawstime.domain.post.entity.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DeletePostService {
+  // PostRepository를 주입받습니다.
+  private final PostRepository postRepository;
+
+  // 포스트를 삭제하는 메서드
+
+  public void deletePost(Long postId) {
+    // 1. 포스트 조회
+    Post post = postRepository.findById(postId)
+        .orElseThrow(() -> new IllegalArgumentException("포스트가 존재하지 않습니다."));
+
+    // 2. 이미 삭제된 포스트인 경우 예외 처리
+    if (post.isDelete()) {
+      throw new IllegalArgumentException("이미 삭제된 포스트입니다.");
+    }
+
+    // 3. 포스트를 소프트 딜리트 상태로 변경
+    post.softDelete();  // Post 엔티티의 softDelete 메서드를 호출하여 삭제 처리
+
+    // 4. 변경된 포스트를 저장
+    postRepository.save(post);
+  }
+
+}

--- a/src/main/java/com/pawstime/pawstime/domain/post/service/ReadPostService.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/service/ReadPostService.java
@@ -34,4 +34,15 @@ public class ReadPostService {
     return postRepository.findById(postId)
       .orElseThrow(() ->new RuntimeException("해당 게시글 id가 없습니다. " + postId));
   }
+
+
+  // 포스트가 존재하는지 확인하고, 이미 삭제된 포스트인지 체크
+  public void checkPostExists(Long postId) {
+    Post post = postRepository.findById(postId)
+        .orElseThrow(() -> new IllegalArgumentException("포스트가 존재하지 않습니다."));
+
+    if (post.isDelete()) {
+      throw new IllegalArgumentException("이미 삭제된 포스트입니다.");
+    }
+  }
 }

--- a/src/main/java/com/pawstime/pawstime/global/entity/BaseEntity.java
+++ b/src/main/java/com/pawstime/pawstime/global/entity/BaseEntity.java
@@ -24,4 +24,8 @@ public abstract class BaseEntity {
 
   @Column(name = "is_delete")
   private boolean isDelete = false;
+
+  public void softDelete() {
+    isDelete = true;
+  }
 }


### PR DESCRIPTION
## 📝 설명 (Description)
간단하게 무엇을 변경했는지 설명해주세요. <br>
변경의 목적과 관련된 내용을 적어주세요.

이번 PR에서는 게시글 삭제 기능을 추가했습니다. 해당 기능은 소프트 삭제 방식으로 구현되어, 삭제된 게시글은 실제로 DB에서 삭제되지 않고 isDelete 필드를 true로 설정하여 논리적으로 삭제된 상태로 처리됩니다.

--- 

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:
- [x] 변경사항 1 :  PostController에 게시글 삭제 API 추가:

@DeleteMapping("/posts/{postId}")를 사용하여 게시글 삭제 요청을 처리.
삭제된 게시글의 경우, 이미 삭제되었음을 알리는 예외 처리 추가.

- [x] 변경사항 2 : PostFacade에 deletePost 메서드 추가:

Facade에서 DeletePostService의 deletePost 메서드를 호출하여 게시글 삭제 기능을 구현.

- [x] 변경사항3 :DeletePostService에 소프트 삭제 로직 추가:

게시글을 조회하고, 이미 삭제된 경우 예외를 던지며, 그렇지 않으면 softDelete() 메서드를 통해 isDelete 값을 true로 설정하여 삭제 처리.


---

## 📌 참고 사항 (Additional Notes)
추가적인 설명이나 주의해야 할 사항이 있다면 적어주세요.<br>
예: 의존성 추가, 환경 설정 변경 등.


소프트 삭제 방식: 삭제된 게시글은 실제 DB에서 삭제되지 않고 isDelete 컬럼을 true로 설정하여 삭제된 상태로 처리됩니다.
예외 처리: 삭제하려는 게시글이 이미 삭제된 상태일 경우, IllegalArgumentException을 던져서 "이미 삭제된 게시글입니다"라는 메시지를 반환합니다.