### PR TITLE
feaet:게시글 상세 조회

### DIFF
--- a/src/main/java/com/pawstime/pawstime/domain/post/controller/PostController.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/controller/PostController.java
@@ -2,6 +2,7 @@ package com.pawstime.pawstime.domain.post.controller;
 
 import com.pawstime.pawstime.domain.post.dto.req.CreatePostReqDto;
 import com.pawstime.pawstime.domain.post.dto.req.UpdatePostReqDto;
+import com.pawstime.pawstime.domain.post.dto.resp.GetDetailPostRespDto;
 import com.pawstime.pawstime.domain.post.facade.PostFacade;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -10,54 +11,47 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @Tag(name = "Post", description = "게시글 API")
 @RestController
 @RequestMapping("/post")
 @RequiredArgsConstructor
-public class PostController {
+  public class PostController {
 
-  private final PostFacade postFacade;
+    private final PostFacade postFacade;
 
-  @Operation(summary = "게시글 생성", description = "새로운 게시글을 생성할 수 있습니다.")
-  @PostMapping("/posts")
-  public ResponseEntity<String> createPost(@RequestBody @Valid CreatePostReqDto req,
-      BindingResult bindingResult) {
-    // 유효성 검사 오류가 있을 경우 처리
-    if (bindingResult.hasErrors()) {
-      StringBuilder errorMessages = new StringBuilder();
-      bindingResult.getAllErrors().forEach(error ->
-          errorMessages.append(error.getDefaultMessage()).append("\n")
-      );
-      return ResponseEntity.badRequest().body("유효성 검사 실패: \n" + errorMessages.toString());
+    @Operation(summary = "게시글 생성", description = "새로운 게시글을 생성할 수 있습니다.")
+    @PostMapping("/posts")
+    public ResponseEntity<String> createPost(@RequestBody @Valid CreatePostReqDto req,
+                                             BindingResult bindingResult) {
+      // 유효성 검사 오류가 있을 경우 처리
+      if (bindingResult.hasErrors()) {
+        StringBuilder errorMessages = new StringBuilder();
+        bindingResult.getAllErrors().forEach(error ->
+                errorMessages.append(error.getDefaultMessage()).append("\n")
+        );
+        return ResponseEntity.badRequest().body("유효성 검사 실패: \n" + errorMessages.toString());
+      }
+      try {
+        postFacade.createPost(req);
+        return ResponseEntity.ok().body("게시글 생성이 완료되었습니다.");
+      } catch (Exception e) {
+        return ResponseEntity.badRequest().body("게시글 생성 중 오류가 발생했습니다. " + e.getMessage());
+      }
     }
-    try {
-      postFacade.createPost(req);
-      return ResponseEntity.ok().body("게시글 생성이 완료되었습니다.");
-    } catch (Exception e) {
-      return ResponseEntity.badRequest().body("게시글 생성 중 오류가 발생했습니다. " + e.getMessage());
-    }
-  }
 
-  @Operation(summary = "게시글 수정", description = "게시글을 수정할 수 있습니다.")
-  @PutMapping("/posts/{postId}")
-  public ResponseEntity<String> updatePost(@PathVariable Long postId,
-      @RequestBody UpdatePostReqDto req, BindingResult bindingResult) {
-    {
+    @Operation(summary = "게시글 수정", description = "게시글을 수정할 수 있습니다.")
+    @PutMapping("/posts/{postId}")
+    public ResponseEntity<String> updatePost(@PathVariable Long postId,
+                                             @RequestBody UpdatePostReqDto req, BindingResult bindingResult) {
       // 유효성 검사 오류 처리
       if (bindingResult.hasErrors()) {
         String errorMessage = bindingResult.getFieldErrors().stream()
-            .map(error -> error.getDefaultMessage())
-            .findFirst()
-            .orElse("유효하지 않은 입력입니다.");
+                .map(error -> error.getDefaultMessage())
+                .findFirst()
+                .orElse("유효하지 않은 입력입니다.");
         return ResponseEntity.badRequest().body(errorMessage);
       }
       try {
@@ -67,19 +61,30 @@ public class PostController {
         return ResponseEntity.badRequest().body("게시글 수정 중 오류가 발생했습니다. " + e.getMessage());
       }
     }
-  }
-  @Operation(summary = "게시글 삭제", description = "게시글을 삭제할 수 있습니다.")
-  @DeleteMapping("/posts/{postId}")
-  public ResponseEntity<String> deletePost(@PathVariable Long postId) {
-    try {
-      postFacade.deletePost(postId);
-      return ResponseEntity.ok("게시글 삭제가 완료되었습니다.");
-    } catch (IllegalArgumentException e) {
-      // 이미 삭제된 게시글인 경우
-      return ResponseEntity.badRequest().body("삭제할 수 없는 게시글입니다: " + e.getMessage());
-    } catch (Exception e) {
-      // 기타 예외 처리
-      return ResponseEntity.badRequest().body("게시글 삭제 중 오류가 발생했습니다. " + e.getMessage());
+
+    @Operation(summary = "게시글 삭제", description = "게시글을 삭제할 수 있습니다.")
+    @DeleteMapping("/posts/{postId}")
+    public ResponseEntity<String> deletePost(@PathVariable Long postId) {
+      try {
+        postFacade.deletePost(postId);
+        return ResponseEntity.ok("게시글 삭제가 완료되었습니다.");
+      } catch (IllegalArgumentException e) {
+        // 이미 삭제된 게시글인 경우
+        return ResponseEntity.badRequest().body("삭제할 수 없는 게시글입니다: " + e.getMessage());
+      } catch (Exception e) {
+        return ResponseEntity.badRequest().body("게시글 삭제 중 오류가 발생했습니다. " + e.getMessage());
+      }
+    }
+
+    @Operation(summary = "게시글 상세 조회", description = "게시글id로 상세조회를 할 수 있습니다.")
+    @GetMapping("/posts/{postId}")
+    public ResponseEntity<?> getDetailPost(@PathVariable Long postId) {
+      try {
+        GetDetailPostRespDto postRespDto = postFacade.getDetailPost(postId);
+        return ResponseEntity.ok(postRespDto);
+      } catch (Exception e) {
+        return ResponseEntity.badRequest().body("게시글 조회 중 오류가 발생했습니다. " + e.getMessage());
+      }
     }
   }
-}
+

--- a/src/main/java/com/pawstime/pawstime/domain/post/dto/resp/GetDetailPostRespDto.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/dto/resp/GetDetailPostRespDto.java
@@ -1,0 +1,28 @@
+package com.pawstime.pawstime.domain.post.dto.resp;
+
+import com.pawstime.pawstime.domain.post.entity.Post;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record GetDetailPostRespDto(
+        Long postId,
+        String title,
+        String content,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+        //String nick  작성자 닉네임
+) {
+    public static GetDetailPostRespDto from(Post post) {
+       // String nick = post.getUser() != null ? post.getUser().getNick() : "알 수 없음"; // 예시: 작성자 닉네임 처리
+        return GetDetailPostRespDto.builder()
+                .postId(post.getPostId())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .createdAt(post.getCreatedAt())
+                .updatedAt(post.getUpdatedAt())
+               // .nick(nick)
+                .build();
+    }
+}

--- a/src/main/java/com/pawstime/pawstime/domain/post/entity/Post.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/entity/Post.java
@@ -65,6 +65,4 @@ public class Post extends BaseEntity {
     this.views += 1;
   }
 
-
-
 }

--- a/src/main/java/com/pawstime/pawstime/domain/post/facade/PostFacade.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/facade/PostFacade.java
@@ -3,11 +3,9 @@ package com.pawstime.pawstime.domain.post.facade;
 import com.pawstime.pawstime.domain.board.entity.Board;
 import com.pawstime.pawstime.domain.post.dto.req.CreatePostReqDto;
 import com.pawstime.pawstime.domain.post.dto.req.UpdatePostReqDto;
+import com.pawstime.pawstime.domain.post.dto.resp.GetDetailPostRespDto;
 import com.pawstime.pawstime.domain.post.entity.Post;
-import com.pawstime.pawstime.domain.post.service.CreatePostService;
-import com.pawstime.pawstime.domain.post.service.DeletePostService;
-import com.pawstime.pawstime.domain.post.service.ReadPostService;
-import com.pawstime.pawstime.domain.post.service.UpdatePostService;
+import com.pawstime.pawstime.domain.post.service.*;
 import com.pawstime.pawstime.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,41 +22,42 @@ public class PostFacade {
   private final CreatePostService createPostService;
   private final UpdatePostService updatePostService;
   private final DeletePostService deletePostService;
+  private final GetDetailPostService getDetailPostService;
 
   public void createPost(CreatePostReqDto req) {
-
-    /*
-    User user = readPostService.findUserById(req.userId());
-    if(user == null){
-      throw new RuntimeException("해당 User ID는 존재하지 않습니다.");
-    }
-*/
     Board board = readPostService.findBoardById(req.boardId());
     if (board == null) {
       throw new RuntimeException("해당 Board ID는 존재하지 않습니다.");
     }
 
-    //DTO를 엔티티로 변환
+    // DTO를 엔티티로 변환하여 게시글 생성
     Post post = req.toEntity(board);
     createPostService.createPost(post);
   }
 
-  //게시글 수정
+  // 게시글 수정
   public void updatePost(Long postId, UpdatePostReqDto req) {
+    // 게시글이 삭제된 상태인지 체크
+    readPostService.checkPostExists(postId);
+
     Post existingPost = readPostService.findById(postId);
-
-    if (existingPost == null) {
-      throw new RuntimeException("해당 id의 게시글은 존재하지 않습니다.");
-    }
-
-    //수정 서비스 호출
     updatePostService.updatePost(existingPost, req);
   }
 
+  // 게시글 삭제
   public void deletePost(Long postId) {
+    // 게시글이 삭제된 상태인지 체크
+    readPostService.checkPostExists(postId);
 
     deletePostService.deletePost(postId);
   }
 
+  // 게시글 상세 조회
+  public GetDetailPostRespDto getDetailPost(Long postId) {
+    // 게시글이 삭제된 상태인지 체크
+    readPostService.checkPostExists(postId);
 
+    Post post = readPostService.findById(postId);
+    return getDetailPostService.getDetailPost(postId);  // DTO 반환
+  }
 }

--- a/src/main/java/com/pawstime/pawstime/domain/post/service/GetDetailPostService.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/service/GetDetailPostService.java
@@ -1,0 +1,21 @@
+package com.pawstime.pawstime.domain.post.service;
+
+import com.pawstime.pawstime.domain.post.dto.resp.GetDetailPostRespDto;
+import com.pawstime.pawstime.domain.post.entity.Post;
+import com.pawstime.pawstime.domain.post.entity.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GetDetailPostService {
+    private final PostRepository postRepository;
+
+    public GetDetailPostRespDto getDetailPost(Long postId){
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new RuntimeException("해당 게시글이 존재하지 않습니다."));
+
+        return GetDetailPostRespDto.from(post);  // DTO 반환
+
+    }
+}

--- a/src/main/java/com/pawstime/pawstime/domain/post/service/ReadPostService.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/service/ReadPostService.java
@@ -35,11 +35,10 @@ public class ReadPostService {
       .orElseThrow(() ->new RuntimeException("해당 게시글 id가 없습니다. " + postId));
   }
 
-
   // 포스트가 존재하는지 확인하고, 이미 삭제된 포스트인지 체크
   public void checkPostExists(Long postId) {
     Post post = postRepository.findById(postId)
-        .orElseThrow(() -> new IllegalArgumentException("포스트가 존재하지 않습니다."));
+            .orElseThrow(() -> new IllegalArgumentException("포스트가 존재하지 않습니다."));
 
     if (post.isDelete()) {
       throw new IllegalArgumentException("이미 삭제된 포스트입니다.");


### PR DESCRIPTION
## 📝 설명 (Description)
간단하게 무엇을 변경했는지 설명해주세요. <br>
변경의 목적과 관련된 내용을 적어주세요.

게시글 상세 조회 기능을 구현했습니다. getDetailPost API를 통해 게시글의 ID로 해당 게시글의 세부 정보를 조회할 수 있도록 했습니다. 게시글의 제목, 내용, 작성일 등을 반환하며, 게시글이 존재하지 않을 경우 400 오류인 게시글 조회 중 오류가 발생했습니다. 가 발생하도록 처리했습니다.

--- 

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:
- [x] getDetailPost API 구현: 게시글 ID를 기반으로 게시글의 상세 정보를 조회하는 API를 추가했습니다. 해당 API는 게시글이 존재하지 않을 경우 오류 메시지를 반환합니다.
- [x] PostFacade 연동: PostController에서 PostFacade를 호출하여 게시글 정보를 조회합니다.
- [x] 예외 처리 추가: 게시글 조회 시 발생할 수 있는 예외를 처리하여 사용자에게 적절한 오류 메시지를 반환합니다.

---

## 📌 참고 사항 (Additional Notes)
추가적인 설명이나 주의해야 할 사항이 있다면 적어주세요.<br>
예: 의존성 추가, 환경 설정 변경 등.

유저 엔티티와 이미지 엔티티 미구현: 현재 유저 정보와 이미지 정보가 포함되지 않으므로, 닉네임 및 이미지 관련 데이터는 반환되지 않습니다. 해당 엔티티들이 구현되면 추가적으로 해당 정보를 포함할 수 있습니다.