### PR TITLE
feat:게시글 목록 조회

### DIFF
--- a/src/main/java/com/pawstime/pawstime/domain/post/controller/PostController.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/controller/PostController.java
@@ -3,88 +3,134 @@ package com.pawstime.pawstime.domain.post.controller;
 import com.pawstime.pawstime.domain.post.dto.req.CreatePostReqDto;
 import com.pawstime.pawstime.domain.post.dto.req.UpdatePostReqDto;
 import com.pawstime.pawstime.domain.post.dto.resp.GetDetailPostRespDto;
+import com.pawstime.pawstime.domain.post.dto.resp.GetListPostRespDto;
+import com.pawstime.pawstime.domain.post.entity.repository.PostRepository;
 import com.pawstime.pawstime.domain.post.facade.PostFacade;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
+
+
 
 @Slf4j
 @Tag(name = "Post", description = "게시글 API")
 @RestController
 @RequestMapping("/post")
 @RequiredArgsConstructor
-  public class PostController {
+public class PostController {
 
     private final PostFacade postFacade;
+    private final PostRepository postRepository;
 
     @Operation(summary = "게시글 생성", description = "새로운 게시글을 생성할 수 있습니다.")
     @PostMapping("/posts")
     public ResponseEntity<String> createPost(@RequestBody @Valid CreatePostReqDto req,
                                              BindingResult bindingResult) {
-      // 유효성 검사 오류가 있을 경우 처리
-      if (bindingResult.hasErrors()) {
-        StringBuilder errorMessages = new StringBuilder();
-        bindingResult.getAllErrors().forEach(error ->
-                errorMessages.append(error.getDefaultMessage()).append("\n")
-        );
-        return ResponseEntity.badRequest().body("유효성 검사 실패: \n" + errorMessages.toString());
-      }
-      try {
-        postFacade.createPost(req);
-        return ResponseEntity.ok().body("게시글 생성이 완료되었습니다.");
-      } catch (Exception e) {
-        return ResponseEntity.badRequest().body("게시글 생성 중 오류가 발생했습니다. " + e.getMessage());
-      }
+        // 유효성 검사 오류가 있을 경우 처리
+        if (bindingResult.hasErrors()) {
+            StringBuilder errorMessages = new StringBuilder();
+            bindingResult.getAllErrors().forEach(error ->
+                    errorMessages.append(error.getDefaultMessage()).append("\n")
+            );
+            return ResponseEntity.badRequest().body("유효성 검사 실패: \n" + errorMessages.toString());
+        }
+        try {
+            postFacade.createPost(req);
+            return ResponseEntity.ok().body("게시글 생성이 완료되었습니다.");
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body("게시글 생성 중 오류가 발생했습니다. " + e.getMessage());
+        }
     }
 
     @Operation(summary = "게시글 수정", description = "게시글을 수정할 수 있습니다.")
     @PutMapping("/posts/{postId}")
     public ResponseEntity<String> updatePost(@PathVariable Long postId,
                                              @RequestBody UpdatePostReqDto req, BindingResult bindingResult) {
-      // 유효성 검사 오류 처리
-      if (bindingResult.hasErrors()) {
-        String errorMessage = bindingResult.getFieldErrors().stream()
-                .map(error -> error.getDefaultMessage())
-                .findFirst()
-                .orElse("유효하지 않은 입력입니다.");
-        return ResponseEntity.badRequest().body(errorMessage);
-      }
-      try {
-        postFacade.updatePost(postId, req);
-        return ResponseEntity.ok().body("게시글 수정이 완료되었습니다.");
-      } catch (Exception e) {
-        return ResponseEntity.badRequest().body("게시글 수정 중 오류가 발생했습니다. " + e.getMessage());
-      }
+        // 유효성 검사 오류 처리
+        if (bindingResult.hasErrors()) {
+            String errorMessage = bindingResult.getFieldErrors().stream()
+                    .map(error -> error.getDefaultMessage())
+                    .findFirst()
+                    .orElse("유효하지 않은 입력입니다.");
+            return ResponseEntity.badRequest().body(errorMessage);
+        }
+        try {
+            postFacade.updatePost(postId, req);
+            return ResponseEntity.ok().body("게시글 수정이 완료되었습니다.");
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body("게시글 수정 중 오류가 발생했습니다. " + e.getMessage());
+        }
     }
 
     @Operation(summary = "게시글 삭제", description = "게시글을 삭제할 수 있습니다.")
     @DeleteMapping("/posts/{postId}")
     public ResponseEntity<String> deletePost(@PathVariable Long postId) {
-      try {
-        postFacade.deletePost(postId);
-        return ResponseEntity.ok("게시글 삭제가 완료되었습니다.");
-      } catch (IllegalArgumentException e) {
-        // 이미 삭제된 게시글인 경우
-        return ResponseEntity.badRequest().body("삭제할 수 없는 게시글입니다: " + e.getMessage());
-      } catch (Exception e) {
-        return ResponseEntity.badRequest().body("게시글 삭제 중 오류가 발생했습니다. " + e.getMessage());
-      }
+        try {
+            postFacade.deletePost(postId);
+            return ResponseEntity.ok("게시글 삭제가 완료되었습니다.");
+        } catch (IllegalArgumentException e) {
+            // 이미 삭제된 게시글인 경우
+            return ResponseEntity.badRequest().body("삭제할 수 없는 게시글입니다: " + e.getMessage());
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body("게시글 삭제 중 오류가 발생했습니다. " + e.getMessage());
+        }
     }
 
     @Operation(summary = "게시글 상세 조회", description = "게시글id로 상세조회를 할 수 있습니다.")
     @GetMapping("/posts/{postId}")
     public ResponseEntity<?> getDetailPost(@PathVariable Long postId) {
-      try {
-        GetDetailPostRespDto postRespDto = postFacade.getDetailPost(postId);
-        return ResponseEntity.ok(postRespDto);
-      } catch (Exception e) {
-        return ResponseEntity.badRequest().body("게시글 조회 중 오류가 발생했습니다. " + e.getMessage());
-      }
+        try {
+            GetDetailPostRespDto postRespDto = postFacade.getDetailPost(postId);
+            return ResponseEntity.ok(postRespDto);
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body("게시글 조회 중 오류가 발생했습니다. " + e.getMessage());
+        }
     }
-  }
 
+    @Operation(summary = "게시글 목록 조회", description = "게시글 목록조회를 할 수 있습니다.")
+    @GetMapping("/posts")
+    public ResponseEntity<?> getPosts(
+            @RequestParam(required = false) Long boardId,  // 특정 게시판 필터링
+            @RequestParam(required = false) String keyword,  // 제목/내용 검색
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "createdAt,desc") String sort) {
+
+        // sort 파라미터 분해
+        String[] sortParams = sort.split(",");
+        Sort.Direction direction = sortParams[1].equalsIgnoreCase("asc") ? Sort.Direction.ASC : Sort.Direction.DESC;
+
+        // sort 기준 설정 (기본값: createdAt)
+        String sortField = sortParams[0];
+        switch (sortField) {
+            case "views":
+                sortField = "views";  // 조회수 기준
+                break;
+            case "title":
+                sortField = "title";  // 제목(가나다순) 기준
+                break;
+            case "createdAt":
+            default:
+                sortField = "createdAt";  // 기본적으로 작성일 기준
+                break;
+        }
+
+        Pageable pageable = PageRequest.of(page, size, Sort.by(direction, sortField));  // Pageable 생성
+
+        // PostFacade를 통해 게시글 가져오기 (검색 및 게시판 필터링 포함)
+        Page<GetListPostRespDto> posts = postFacade.getPosts(boardId, keyword, keyword, sortField, pageable);
+
+        return ResponseEntity.ok().body(posts.getContent());
+    }
+
+}

--- a/src/main/java/com/pawstime/pawstime/domain/post/controller/PostController.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/controller/PostController.java
@@ -2,6 +2,7 @@ package com.pawstime.pawstime.domain.post.controller;
 
 import com.pawstime.pawstime.domain.post.dto.req.CreatePostReqDto;
 import com.pawstime.pawstime.domain.post.dto.req.UpdatePostReqDto;
+import com.pawstime.pawstime.domain.post.dto.resp.GetDetailPostRespDto;
 import com.pawstime.pawstime.domain.post.facade.PostFacade;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -10,54 +11,47 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @Tag(name = "Post", description = "게시글 API")
 @RestController
 @RequestMapping("/post")
 @RequiredArgsConstructor
-public class PostController {
+  public class PostController {
 
-  private final PostFacade postFacade;
+    private final PostFacade postFacade;
 
-  @Operation(summary = "게시글 생성", description = "새로운 게시글을 생성할 수 있습니다.")
-  @PostMapping("/posts")
-  public ResponseEntity<String> createPost(@RequestBody @Valid CreatePostReqDto req,
-      BindingResult bindingResult) {
-    // 유효성 검사 오류가 있을 경우 처리
-    if (bindingResult.hasErrors()) {
-      StringBuilder errorMessages = new StringBuilder();
-      bindingResult.getAllErrors().forEach(error ->
-          errorMessages.append(error.getDefaultMessage()).append("\n")
-      );
-      return ResponseEntity.badRequest().body("유효성 검사 실패: \n" + errorMessages.toString());
+    @Operation(summary = "게시글 생성", description = "새로운 게시글을 생성할 수 있습니다.")
+    @PostMapping("/posts")
+    public ResponseEntity<String> createPost(@RequestBody @Valid CreatePostReqDto req,
+                                             BindingResult bindingResult) {
+      // 유효성 검사 오류가 있을 경우 처리
+      if (bindingResult.hasErrors()) {
+        StringBuilder errorMessages = new StringBuilder();
+        bindingResult.getAllErrors().forEach(error ->
+                errorMessages.append(error.getDefaultMessage()).append("\n")
+        );
+        return ResponseEntity.badRequest().body("유효성 검사 실패: \n" + errorMessages.toString());
+      }
+      try {
+        postFacade.createPost(req);
+        return ResponseEntity.ok().body("게시글 생성이 완료되었습니다.");
+      } catch (Exception e) {
+        return ResponseEntity.badRequest().body("게시글 생성 중 오류가 발생했습니다. " + e.getMessage());
+      }
     }
-    try {
-      postFacade.createPost(req);
-      return ResponseEntity.ok().body("게시글 생성이 완료되었습니다.");
-    } catch (Exception e) {
-      return ResponseEntity.badRequest().body("게시글 생성 중 오류가 발생했습니다. " + e.getMessage());
-    }
-  }
 
-  @Operation(summary = "게시글 수정", description = "게시글을 수정할 수 있습니다.")
-  @PutMapping("/posts/{postId}")
-  public ResponseEntity<String> updatePost(@PathVariable Long postId,
-      @RequestBody UpdatePostReqDto req, BindingResult bindingResult) {
-    {
+    @Operation(summary = "게시글 수정", description = "게시글을 수정할 수 있습니다.")
+    @PutMapping("/posts/{postId}")
+    public ResponseEntity<String> updatePost(@PathVariable Long postId,
+                                             @RequestBody UpdatePostReqDto req, BindingResult bindingResult) {
       // 유효성 검사 오류 처리
       if (bindingResult.hasErrors()) {
         String errorMessage = bindingResult.getFieldErrors().stream()
-            .map(error -> error.getDefaultMessage())
-            .findFirst()
-            .orElse("유효하지 않은 입력입니다.");
+                .map(error -> error.getDefaultMessage())
+                .findFirst()
+                .orElse("유효하지 않은 입력입니다.");
         return ResponseEntity.badRequest().body(errorMessage);
       }
       try {
@@ -67,19 +61,30 @@ public class PostController {
         return ResponseEntity.badRequest().body("게시글 수정 중 오류가 발생했습니다. " + e.getMessage());
       }
     }
-  }
-  @Operation(summary = "게시글 삭제", description = "게시글을 삭제할 수 있습니다.")
-  @DeleteMapping("/posts/{postId}")
-  public ResponseEntity<String> deletePost(@PathVariable Long postId) {
-    try {
-      postFacade.deletePost(postId);
-      return ResponseEntity.ok("게시글 삭제가 완료되었습니다.");
-    } catch (IllegalArgumentException e) {
-      // 이미 삭제된 게시글인 경우
-      return ResponseEntity.badRequest().body("삭제할 수 없는 게시글입니다: " + e.getMessage());
-    } catch (Exception e) {
-      // 기타 예외 처리
-      return ResponseEntity.badRequest().body("게시글 삭제 중 오류가 발생했습니다. " + e.getMessage());
+
+    @Operation(summary = "게시글 삭제", description = "게시글을 삭제할 수 있습니다.")
+    @DeleteMapping("/posts/{postId}")
+    public ResponseEntity<String> deletePost(@PathVariable Long postId) {
+      try {
+        postFacade.deletePost(postId);
+        return ResponseEntity.ok("게시글 삭제가 완료되었습니다.");
+      } catch (IllegalArgumentException e) {
+        // 이미 삭제된 게시글인 경우
+        return ResponseEntity.badRequest().body("삭제할 수 없는 게시글입니다: " + e.getMessage());
+      } catch (Exception e) {
+        return ResponseEntity.badRequest().body("게시글 삭제 중 오류가 발생했습니다. " + e.getMessage());
+      }
+    }
+
+    @Operation(summary = "게시글 상세 조회", description = "게시글id로 상세조회를 할 수 있습니다.")
+    @GetMapping("/posts/{postId}")
+    public ResponseEntity<?> getDetailPost(@PathVariable Long postId) {
+      try {
+        GetDetailPostRespDto postRespDto = postFacade.getDetailPost(postId);
+        return ResponseEntity.ok(postRespDto);
+      } catch (Exception e) {
+        return ResponseEntity.badRequest().body("게시글 조회 중 오류가 발생했습니다. " + e.getMessage());
+      }
     }
   }
-}
+

--- a/src/main/java/com/pawstime/pawstime/domain/post/dto/resp/GetDetailPostRespDto.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/dto/resp/GetDetailPostRespDto.java
@@ -1,0 +1,28 @@
+package com.pawstime.pawstime.domain.post.dto.resp;
+
+import com.pawstime.pawstime.domain.post.entity.Post;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record GetDetailPostRespDto(
+        Long postId,
+        String title,
+        String content,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+        //String nick  작성자 닉네임
+) {
+    public static GetDetailPostRespDto from(Post post) {
+       // String nick = post.getUser() != null ? post.getUser().getNick() : "알 수 없음"; // 예시: 작성자 닉네임 처리
+        return GetDetailPostRespDto.builder()
+                .postId(post.getPostId())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .createdAt(post.getCreatedAt())
+                .updatedAt(post.getUpdatedAt())
+               // .nick(nick)
+                .build();
+    }
+}

--- a/src/main/java/com/pawstime/pawstime/domain/post/dto/resp/GetListPostRespDto.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/dto/resp/GetListPostRespDto.java
@@ -1,0 +1,34 @@
+package com.pawstime.pawstime.domain.post.dto.resp;
+
+import com.pawstime.pawstime.domain.post.entity.Post;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record GetListPostRespDto(
+        Long id,                 // 게시글 ID
+        String title,            // 게시글 제목
+        String contentPreview,   // 내용 미리보기
+        LocalDateTime createdAt, // 작성일
+        LocalDateTime updatedAt, // 수정일
+        int views,               // 조회수
+        int likesCount,          // 좋아요 수
+        String category          // 게시글 카테고리
+) {
+    // Post 엔티티를 DTO로 변환하는 메서드
+    public static GetListPostRespDto from(Post post) {
+        return GetListPostRespDto.builder()
+                .id(post.getPostId())                        // 게시글 ID
+                .title(post.getTitle())                      // 게시글 제목
+                .contentPreview(post.getContent().length() > 100
+                        ? post.getContent().substring(0, 100) + "..." // 내용 미리보기
+                        : post.getContent())
+                .createdAt(post.getCreatedAt())              // 작성일
+                .updatedAt(post.getUpdatedAt())              // 수정일
+                .views(post.getViews())                      // 조회수
+                .likesCount(post.getLikesCount())            // 좋아요 수
+                .category(post.getCategory() != null ? post.getCategory().name() : "") // 카테고리
+                .build();
+    }
+}

--- a/src/main/java/com/pawstime/pawstime/domain/post/entity/Post.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/entity/Post.java
@@ -65,6 +65,4 @@ public class Post extends BaseEntity {
     this.views += 1;
   }
 
-
-
 }

--- a/src/main/java/com/pawstime/pawstime/domain/post/entity/repository/PostRepository.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/entity/repository/PostRepository.java
@@ -1,8 +1,52 @@
 package com.pawstime.pawstime.domain.post.entity.repository;
 
 import com.pawstime.pawstime.domain.post.entity.Post;
+import org.apache.ibatis.annotations.Param;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+    // 모든 게시판의 모든 게시글 조회 (삭제되지 않은 게시글만 조회)
+    Page<Post> findByIsDeleteFalse(Pageable pageable);
+
+    // 특정 게시판의 게시글 조회 (삭제되지 않은 게시글만)
+    Page<Post> findByBoard_boardIdAndIsDeleteFalse(Long boardId, Pageable pageable);
+
+    // 제목과 내용에서 검색 (삭제되지 않은 게시글만)
+    Page<Post> findByTitleContainingOrContentContainingAndIsDeleteFalse(String titleKeyword, String contentKeyword, Pageable pageable);
+
+    // 제목과 내용에서 검색 (특정 게시판, 삭제되지 않은 게시글만)
+    Page<Post> findByTitleContainingOrContentContainingAndBoard_boardIdAndIsDeleteFalse(
+            String titleKeyword, String contentKeyword, Long boardId, Pageable pageable);
+
+    // 제목과 내용에서 검색 (특정 게시판, 삭제되지 않은 게시글만) - 수정
+    @Query("SELECT p FROM Post p WHERE p.board.boardId = :boardId AND p.isDelete = false " +
+            "AND (p.title LIKE %:titleKeyword% OR p.content LIKE %:contentKeyword%)")
+    Page<Post> findByBoardIdAndIsDeleteFalseAndTitleContainingOrContentContaining(
+            @Param("boardId") Long boardId,
+            @Param("titleKeyword") String titleKeyword,
+            @Param("contentKeyword") String contentKeyword,
+            Pageable pageable);
+
+    // 최신순 (작성일 기준, 삭제되지 않은 게시글만)
+    Page<Post> findAllByIsDeleteFalseOrderByCreatedAtDesc(Pageable pageable);
+
+    // 조회수 기준 내림차순 (삭제되지 않은 게시글만)
+    Page<Post> findAllByIsDeleteFalseOrderByViewsDesc(Pageable pageable);
+
+    // 가나다순 (제목 기준, 삭제되지 않은 게시글만)
+    Page<Post> findAllByIsDeleteFalseOrderByTitleAsc(Pageable pageable);
+
+    // 제목으로 게시글 조회 (삭제된 게시글 제외)
+    Post findByTitle(String title);
+
+    // 특정 게시글 조회 (삭제되지 않은 게시글만)
+    // 특정 게시글 조회 (삭제되지 않은 게시글만)
+    Optional<Post> findByPostIdAndIsDeleteFalse(Long postId);
 
 }

--- a/src/main/java/com/pawstime/pawstime/domain/post/facade/PostFacade.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/facade/PostFacade.java
@@ -3,11 +3,9 @@ package com.pawstime.pawstime.domain.post.facade;
 import com.pawstime.pawstime.domain.board.entity.Board;
 import com.pawstime.pawstime.domain.post.dto.req.CreatePostReqDto;
 import com.pawstime.pawstime.domain.post.dto.req.UpdatePostReqDto;
+import com.pawstime.pawstime.domain.post.dto.resp.GetDetailPostRespDto;
 import com.pawstime.pawstime.domain.post.entity.Post;
-import com.pawstime.pawstime.domain.post.service.CreatePostService;
-import com.pawstime.pawstime.domain.post.service.DeletePostService;
-import com.pawstime.pawstime.domain.post.service.ReadPostService;
-import com.pawstime.pawstime.domain.post.service.UpdatePostService;
+import com.pawstime.pawstime.domain.post.service.*;
 import com.pawstime.pawstime.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,41 +22,42 @@ public class PostFacade {
   private final CreatePostService createPostService;
   private final UpdatePostService updatePostService;
   private final DeletePostService deletePostService;
+  private final GetDetailPostService getDetailPostService;
 
   public void createPost(CreatePostReqDto req) {
-
-    /*
-    User user = readPostService.findUserById(req.userId());
-    if(user == null){
-      throw new RuntimeException("해당 User ID는 존재하지 않습니다.");
-    }
-*/
     Board board = readPostService.findBoardById(req.boardId());
     if (board == null) {
       throw new RuntimeException("해당 Board ID는 존재하지 않습니다.");
     }
 
-    //DTO를 엔티티로 변환
+    // DTO를 엔티티로 변환하여 게시글 생성
     Post post = req.toEntity(board);
     createPostService.createPost(post);
   }
 
-  //게시글 수정
+  // 게시글 수정
   public void updatePost(Long postId, UpdatePostReqDto req) {
+    // 게시글이 삭제된 상태인지 체크
+    readPostService.checkPostExists(postId);
+
     Post existingPost = readPostService.findById(postId);
-
-    if (existingPost == null) {
-      throw new RuntimeException("해당 id의 게시글은 존재하지 않습니다.");
-    }
-
-    //수정 서비스 호출
     updatePostService.updatePost(existingPost, req);
   }
 
+  // 게시글 삭제
   public void deletePost(Long postId) {
+    // 게시글이 삭제된 상태인지 체크
+    readPostService.checkPostExists(postId);
 
     deletePostService.deletePost(postId);
   }
 
+  // 게시글 상세 조회
+  public GetDetailPostRespDto getDetailPost(Long postId) {
+    // 게시글이 삭제된 상태인지 체크
+    readPostService.checkPostExists(postId);
 
+    Post post = readPostService.findById(postId);
+    return getDetailPostService.getDetailPost(postId);  // DTO 반환
+  }
 }

--- a/src/main/java/com/pawstime/pawstime/domain/post/facade/PostFacade.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/facade/PostFacade.java
@@ -4,13 +4,17 @@ import com.pawstime.pawstime.domain.board.entity.Board;
 import com.pawstime.pawstime.domain.post.dto.req.CreatePostReqDto;
 import com.pawstime.pawstime.domain.post.dto.req.UpdatePostReqDto;
 import com.pawstime.pawstime.domain.post.dto.resp.GetDetailPostRespDto;
+import com.pawstime.pawstime.domain.post.dto.resp.GetListPostRespDto;
 import com.pawstime.pawstime.domain.post.entity.Post;
+import com.pawstime.pawstime.domain.post.entity.repository.PostRepository;
 import com.pawstime.pawstime.domain.post.service.*;
-import com.pawstime.pawstime.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+
 
 @Slf4j
 @Transactional
@@ -23,6 +27,7 @@ public class PostFacade {
   private final UpdatePostService updatePostService;
   private final DeletePostService deletePostService;
   private final GetDetailPostService getDetailPostService;
+  private final PostRepository postRepository;
 
   public void createPost(CreatePostReqDto req) {
     Board board = readPostService.findBoardById(req.boardId());
@@ -40,7 +45,7 @@ public class PostFacade {
     // 게시글이 삭제된 상태인지 체크
     readPostService.checkPostExists(postId);
 
-    Post existingPost = readPostService.findById(postId);
+    Post existingPost = readPostService.findPostById(postId);
     updatePostService.updatePost(existingPost, req);
   }
 
@@ -57,7 +62,46 @@ public class PostFacade {
     // 게시글이 삭제된 상태인지 체크
     readPostService.checkPostExists(postId);
 
-    Post post = readPostService.findById(postId);
+    Post post = readPostService.findPostId(postId);
     return getDetailPostService.getDetailPost(postId);  // DTO 반환
   }
+
+  public Page<GetListPostRespDto> getPosts(Long boardId, String titleKeyword, String contentKeyword, String sortBy, Pageable pageable) {
+    Page<Post> posts;
+
+    // 제목과 내용에서 검색
+    if (titleKeyword != null || contentKeyword != null) {
+      posts = postRepository.findByTitleContainingOrContentContainingAndIsDeleteFalse(titleKeyword, contentKeyword, pageable);
+    } else if (boardId != null) {
+      // 게시판 ID 기준으로 게시글 조회
+      posts = postRepository.findByBoard_boardIdAndIsDeleteFalse(boardId, pageable);
+    } else {
+      // 정렬 기준에 맞춰 게시글 조회
+      switch (sortBy) {
+        case "views":
+          posts = postRepository.findAllByIsDeleteFalseOrderByViewsDesc(pageable); // 조회수 내림차순
+          break;
+        case "title":
+          posts = postRepository.findAllByIsDeleteFalseOrderByTitleAsc(pageable); // 가나다순
+          break;
+        case "latest":
+        default:
+          posts = postRepository.findAllByIsDeleteFalseOrderByCreatedAtDesc(pageable); // 최신순
+          break;
+      }
+    }
+
+    // 엔티티(Post)에서 DTO(GetListPostRespDto)로 변환하여 반환
+    return posts.map(post -> GetListPostRespDto.builder()
+            .id(post.getPostId())
+            .title(post.getTitle())
+            .contentPreview(post.getContent().length() > 100 ? post.getContent().substring(0, 100) + "..." : post.getContent())
+            .createdAt(post.getCreatedAt())
+            .updatedAt(post.getUpdatedAt())
+            .views(post.getViews())
+            .likesCount(post.getLikesCount())
+            .category(post.getCategory().name())
+            .build());
+  }
+
 }

--- a/src/main/java/com/pawstime/pawstime/domain/post/service/GetDetailPostService.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/service/GetDetailPostService.java
@@ -1,0 +1,21 @@
+package com.pawstime.pawstime.domain.post.service;
+
+import com.pawstime.pawstime.domain.post.dto.resp.GetDetailPostRespDto;
+import com.pawstime.pawstime.domain.post.entity.Post;
+import com.pawstime.pawstime.domain.post.entity.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GetDetailPostService {
+    private final PostRepository postRepository;
+
+    public GetDetailPostRespDto getDetailPost(Long postId){
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new RuntimeException("해당 게시글이 존재하지 않습니다."));
+
+        return GetDetailPostRespDto.from(post);  // DTO 반환
+
+    }
+}

--- a/src/main/java/com/pawstime/pawstime/domain/post/service/GetListPostService.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/service/GetListPostService.java
@@ -1,0 +1,62 @@
+package com.pawstime.pawstime.domain.post.service;
+
+import com.pawstime.pawstime.domain.post.dto.resp.GetListPostRespDto;
+import com.pawstime.pawstime.domain.post.entity.Post;
+import com.pawstime.pawstime.domain.post.entity.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+
+@Service
+@RequiredArgsConstructor
+public class GetListPostService {
+    private final PostRepository postRepository;
+
+
+    public Page<GetListPostRespDto> getPostList(Pageable pageable, String searchKeyword, String sortBy, Long boardId) {
+        Page<Post> posts;
+
+        // 게시판 ID가 주어진 경우, 게시판 ID로 필터링 (삭제되지 않은 게시글만)
+        if (boardId != null) {
+            posts = postRepository.findByBoard_boardIdAndIsDeleteFalse(boardId, pageable);  // 삭제되지 않은 게시글만 조회
+        } else {
+            // 검색어가 있는 경우, 제목과 내용에서 검색 (삭제되지 않은 게시글만)
+            if (searchKeyword != null && !searchKeyword.isEmpty()) {
+                posts = postRepository.findByTitleContainingOrContentContainingAndIsDeleteFalse(
+                        searchKeyword, searchKeyword, pageable);  // 삭제되지 않은 게시글만 조회
+            } else {
+                // 정렬 기준에 맞춰 게시글 조회 (삭제되지 않은 게시글만)
+                switch (sortBy) {
+                    case "views":
+                        posts = postRepository.findAllByIsDeleteFalseOrderByViewsDesc(pageable);  // 조회수 내림차순
+                        break;
+                    case "title":
+                        posts = postRepository.findAllByIsDeleteFalseOrderByTitleAsc(pageable);  // 가나다순
+                        break;
+                    case "latest":
+                    default:
+                        posts = postRepository.findAllByIsDeleteFalseOrderByCreatedAtDesc(pageable);  // 최신순
+                        break;
+                }
+            }
+        }
+
+        // 엔티티(Post)에서 DTO(GetListPostRespDto)로 변환하여 반환
+        return posts.map(post -> GetListPostRespDto.builder()
+                .id(post.getPostId())
+                .title(post.getTitle())
+                .contentPreview(post.getContent().length() > 100
+                        ? post.getContent().substring(0, 100) + "..."
+                        : post.getContent())
+                .createdAt(post.getCreatedAt())
+                .updatedAt(post.getUpdatedAt())
+                .views(post.getViews())
+                .likesCount(post.getLikesCount())
+                .category(post.getCategory().name())
+                .build());
+    }
+}
+
+

--- a/src/main/java/com/pawstime/pawstime/domain/post/service/ReadPostService.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/service/ReadPostService.java
@@ -2,11 +2,12 @@ package com.pawstime.pawstime.domain.post.service;
 
 import com.pawstime.pawstime.domain.board.entity.Board;
 import com.pawstime.pawstime.domain.board.entity.repository.BoardRepository;
+import com.pawstime.pawstime.domain.post.dto.resp.GetListPostRespDto;
 import com.pawstime.pawstime.domain.post.entity.Post;
 import com.pawstime.pawstime.domain.post.entity.repository.PostRepository;
-import com.pawstime.pawstime.domain.user.entity.User;
-import com.pawstime.pawstime.domain.user.entity.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -14,25 +15,18 @@ import org.springframework.stereotype.Service;
 public class ReadPostService {
 
   private final BoardRepository boardRepository;
-  private final UserRepository userRepository;
   private final PostRepository postRepository;
 
-  /*User를 ID로 조회하는 메서드
-  public User findUserById(Long userId){
-
-    return userRepository.findById(userId)
-        .orElseThrow(() -> new RuntimeException("해당 유저 id가 없습니다. : " + userId));
-  }*/
-
-  //Board를 ID로 조회하는 메서드
-  public Board findBoardById(Long boardId){
+  // Board를 ID로 조회하는 메서드
+  public Board findBoardById(Long boardId) {
     return boardRepository.findById(boardId)
-        .orElseThrow(() -> new RuntimeException("해당 게시판 id가 없습니다. :" + boardId));
+            .orElseThrow(() -> new RuntimeException("해당 게시판 id가 없습니다. :" + boardId));
   }
-  //postId를 조회하는 메서드
-  public Post findById(Long postId){
+
+  // postId를 조회하는 메서드 (삭제된 포스트도 제외해야 함)
+  public Post findPostById(Long postId) {
     return postRepository.findById(postId)
-      .orElseThrow(() ->new RuntimeException("해당 게시글 id가 없습니다. " + postId));
+            .orElseThrow(() -> new RuntimeException("해당 게시글 id가 없습니다. " + postId));
   }
 
   // 포스트가 존재하는지 확인하고, 이미 삭제된 포스트인지 체크
@@ -44,4 +38,63 @@ public class ReadPostService {
       throw new IllegalArgumentException("이미 삭제된 포스트입니다.");
     }
   }
+
+  // 게시글 조회 (특정 게시판, 제목/내용 키워드 검색 포함, 페이징 처리)
+  public Page<GetListPostRespDto> getPosts(Long boardId, String titleKeyword, String contentKeyword, String sortField, Pageable pageable) {
+    Page<Post> posts;
+
+    if (boardId != null) {
+      // 특정 게시판에 대해 제목과 내용 검색
+      posts = postRepository.findByTitleContainingOrContentContainingAndBoard_boardIdAndIsDeleteFalse(
+              titleKeyword, contentKeyword, boardId, pageable);
+    } else {
+      // 게시판 ID 없이 제목과 내용 검색
+      posts = postRepository.findByTitleContainingOrContentContainingAndIsDeleteFalse(
+              titleKeyword, contentKeyword, pageable);
+    }
+
+    return posts.map(GetListPostRespDto::from);  // GetListPostRespDto.from() 사용
+  }
+
+  // 특정 게시판의 게시글 조회 (삭제되지 않은 게시글만)
+  public Page<Post> getPostsByBoard(Long boardId, Pageable pageable) {
+    if (boardId != null) {
+      return postRepository.findByBoard_boardIdAndIsDeleteFalse(boardId, pageable);
+    } else {
+      return postRepository.findAll(pageable);
+    }
+  }
+
+  // 제목과 내용에서 검색 (boardId가 있을 경우 해당 게시판에 한정)
+  public Page<Post> searchPosts(String titleKeyword, String contentKeyword, Long boardId, Pageable pageable) {
+    if (boardId != null) {
+      return postRepository.findByTitleContainingOrContentContainingAndBoard_boardIdAndIsDeleteFalse(
+              titleKeyword, contentKeyword, boardId, pageable);
+    } else {
+      return postRepository.findByTitleContainingOrContentContainingAndIsDeleteFalse(
+              titleKeyword, contentKeyword, pageable);
+    }
+  }
+
+  // 최신순 (작성일 기준, 삭제되지 않은 게시글만)
+  public Page<Post> getPostsSortedByCreatedAt(Pageable pageable) {
+    return postRepository.findAllByIsDeleteFalseOrderByCreatedAtDesc(pageable);
+  }
+
+  // 조회수 기준 내림차순 (삭제되지 않은 게시글만)
+  public Page<Post> getPostsSortedByViews(Pageable pageable) {
+    return postRepository.findAllByIsDeleteFalseOrderByViewsDesc(pageable);
+  }
+
+  // 가나다순 (제목 기준, 삭제되지 않은 게시글만)
+  public Page<Post> getPostsSortedByTitle(Pageable pageable) {
+    return postRepository.findAllByIsDeleteFalseOrderByTitleAsc(pageable);
+  }
+
+  // 게시글을 ID로 조회하는 메서드 (삭제되지 않은 포스트만)
+  public Post findPostId(Long postId) {
+    return postRepository.findByPostIdAndIsDeleteFalse(postId)
+            .orElseThrow(() -> new RuntimeException("해당 게시글 id가 없습니다. " + postId));
+  }
+
 }

--- a/src/main/java/com/pawstime/pawstime/domain/post/service/ReadPostService.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/service/ReadPostService.java
@@ -35,11 +35,10 @@ public class ReadPostService {
       .orElseThrow(() ->new RuntimeException("해당 게시글 id가 없습니다. " + postId));
   }
 
-
   // 포스트가 존재하는지 확인하고, 이미 삭제된 포스트인지 체크
   public void checkPostExists(Long postId) {
     Post post = postRepository.findById(postId)
-        .orElseThrow(() -> new IllegalArgumentException("포스트가 존재하지 않습니다."));
+            .orElseThrow(() -> new IllegalArgumentException("포스트가 존재하지 않습니다."));
 
     if (post.isDelete()) {
       throw new IllegalArgumentException("이미 삭제된 포스트입니다.");


### PR DESCRIPTION
## 📝 설명 (Description)
게시글 목록 조회 기능에 검색과 정렬 기준을 추가하는 내용입니다. 이를 통해 사용자는 제목, 내용에서 키워드 검색을 할 수 있고, 게시판별로도 게시글을 검색할 수 있습니다. 또한, 게시글 목록을 다양한 기준(최신순, 조회수 순, 가나다순 등)으로 정렬할 수 있게 되어 사용자 경험을 개선하고, 필요한 게시글을 더 쉽게 찾을 수 있도록 했습니다.

--- 

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:

검색 기능 추가: 제목과 내용에서 키워드를 검색할 수 있는 기능을 추가했습니다.

 게시판 별 검색 추가: 특정 게시판 내에서만 검색할 수 있는 기능을 추가했습니다.

 정렬 기능 추가: 게시글 목록을 최신순, 조회수 순, 가나다순으로 정렬할 수 있는 기능을 추가했습니다.

 소프트 딜리트 처리: 삭제되지 않은 게시글만 조회 가능하도록 처리했습니다.

![image](https://github.com/user-attachments/assets/28eed9cd-f789-45c0-85d3-d3959fdc3340)


 같은 카테고리만 모아서 조회 가능: 카테고리별로 게시글을 조회할 수 있는 기능을 추가할 예정입니다.

 작성자 기준 조회: 작성자별로 게시글을 조회할 수 있는 기능을 추가할 예정입니다.

 좋아요 순 조회: 게시글을 좋아요 수 기준으로 정렬할 수 있는 기능을 추가할 예정입니다.

 댓글 순 조회: 게시글을 댓글 수 기준으로 정렬할 수 있는 기능을 추가할 예정입니다.

---

## 📌 참고 사항 (Additional Notes)
추가적인 설명이나 주의해야 할 사항이 있다면 적어주세요.<br>

향후, 같은 카테고리로 게시글을 조회하거나, 작성자, 좋아요, 댓글 기준으로도 정렬 및 조회할 수 있는 기능을 추가할 예정입니다.
