### PR TITLE
style: 응답 구조 정의 및 게시판 엔티티에 적용

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
 
   # Spring Boot 애플리케이션 서비스
   springboot:
-    image: dgf0020/pawstime:1.0.0
+    image: dgf0020/pawstime:1.0.1
     container_name: springboot_app
     restart: always
     environment:

--- a/src/main/java/com/pawstime/pawstime/domain/board/controller/BoardController.java
+++ b/src/main/java/com/pawstime/pawstime/domain/board/controller/BoardController.java
@@ -4,12 +4,15 @@ import com.pawstime.pawstime.domain.board.dto.req.CreateBoardReqDto;
 import com.pawstime.pawstime.domain.board.dto.req.UpdateBoardReqDto;
 import com.pawstime.pawstime.domain.board.dto.resp.GetBoardRespDto;
 import com.pawstime.pawstime.domain.board.facade.BoardFacade;
+import com.pawstime.pawstime.global.common.ApiResponse;
+import com.pawstime.pawstime.global.enums.Status;
+import com.pawstime.pawstime.global.exception.CustomException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,6 +20,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
@@ -30,6 +34,25 @@ public class BoardController {
 
   @Operation(summary = "게시판 생성", description = "새로운 게시판을 생성할 수 있습니다.")
   @PostMapping("/boards")
+  @ResponseStatus(HttpStatus.CREATED)
+  public ApiResponse<Void> createBoard(@RequestBody CreateBoardReqDto req) {
+    try {
+      boardFacade.createBoard(req);
+
+      return ApiResponse.generateResp(Status.CREATE, "게시판 생성이 완료되었습니다.", null);
+    } catch (CustomException e) {
+      Status status = Status.valueOf(e.getClass().getSimpleName().replace("Exception", "").toUpperCase());
+      // 예외 이름을 이용해서 Enum타입의 Status를 가져옴. ex) InvalidException => INVALID
+      log.info("** {} **", status);
+      return ApiResponse.generateResp(status, e.getMessage(), null);
+    } catch (Exception e) {
+      return ApiResponse.generateResp(Status.ERROR, "게시판 생성 중 오류가 발생하였습니다 : " + e.getMessage(), null);
+    }
+  }
+
+  /*
+  @Operation(summary = "게시판 생성", description = "새로운 게시판을 생성할 수 있습니다.")
+  @PostMapping("/boards")
   public ResponseEntity<String> createBoard(@RequestBody CreateBoardReqDto req) {
     try {
       boardFacade.createBoard(req);
@@ -39,14 +62,53 @@ public class BoardController {
       return ResponseEntity.badRequest().body("게시판 생성 중 오류가 발생하였습니다 : " + e.getMessage());
     }
   }
+  */
 
+  @Operation(summary = "게시판 상세 조회",
+      description = "board_id를 입력하면 title, description을 조회할 수 있습니다.")
+  @GetMapping("/{boardId}")
+  @ResponseStatus(HttpStatus.OK)
+  public ApiResponse<GetBoardRespDto> getBoard(@PathVariable Long boardId) {
+    try {
+      return ApiResponse.generateResp(Status.SUCCESS, null, boardFacade.getBoard(boardId));
+    } catch (CustomException e) {
+      Status status = Status.valueOf(e.getClass().getSimpleName().replace("Exception", "").toUpperCase());
+      return ApiResponse.generateResp(status, e.getMessage(), null);
+    } catch (Exception e) {
+      return ApiResponse.generateResp(Status.ERROR, "게시판 상세 조회 중 오류가 발생하였습니다 : " + e.getMessage(), null);
+    }
+  }
+
+  /*
   @Operation(summary = "게시판 상세 조회",
       description = "board_id를 입력하면 title, description을 조회할 수 있습니다.")
   @GetMapping("/{boardId}")
   public ResponseEntity<GetBoardRespDto> getBoard(@PathVariable Long boardId) {
     return ResponseEntity.ok().body(boardFacade.getBoard(boardId));
   }
+  */
 
+  @Operation(summary = "게시판 목록 조회", description = "생성되어있는 모든 게시판을 조회합니다.")
+  @GetMapping("/list")
+  public ApiResponse<List<GetBoardRespDto>> getBoardList(
+      @RequestParam(defaultValue = "0") int pageNo,
+      @RequestParam(defaultValue = "10") int pageSize,
+      @RequestParam(defaultValue = "createdAt") String sortBy,
+      @RequestParam(defaultValue = "DESC") String direction
+  ) {
+    try {
+      return ApiResponse.generateResp(Status.SUCCESS, null,
+          boardFacade.getBoardList(pageNo, pageSize, sortBy, direction).getContent());
+    } catch (CustomException e) {
+      Status status = Status.valueOf(e.getClass().getSimpleName().replace("Exception", "").toUpperCase());
+      return ApiResponse.generateResp(status, e.getMessage(), null);
+    } catch (Exception e) {
+      return ApiResponse.generateResp(Status.ERROR, "게시판 목록 조회 중 오류가 발생하였습니다 : " + e.getMessage(), null);
+    }
+
+  }
+
+  /*
   @Operation(summary = "게시판 목록 조회", description = "생성되어있는 모든 게시판을 조회합니다.")
   @GetMapping("/list")
   public ResponseEntity<List<GetBoardRespDto>> getBoardList(
@@ -57,7 +119,24 @@ public class BoardController {
   ) {
     return ResponseEntity.ok().body(boardFacade.getBoardList(pageNo, pageSize, sortBy, direction).getContent());
   }
+  */
 
+  @Operation(summary = "게시판 삭제", description = "선택한 게시판을 삭제합니다.")
+  @PutMapping("/delete/{boardId}")
+  public ApiResponse<Void> deleteBoard(@PathVariable Long boardId) {
+    try {
+      boardFacade.deleteBoard(boardId);
+
+      return ApiResponse.generateResp(Status.DELETE, "게시판이 삭제되었습니다.", null);
+    } catch (CustomException e) {
+      Status status = Status.valueOf(e.getClass().getSimpleName().replace("Exception", "").toUpperCase());
+      return ApiResponse.generateResp(status, e.getMessage(), null);
+    } catch (Exception e) {
+      return ApiResponse.generateResp(Status.ERROR, "게시판 삭제 중 오류가 발생하였습니다 : " + e.getMessage(), null);
+    }
+  }
+
+  /*
   @Operation(summary = "게시판 삭제", description = "선택한 게시판을 삭제합니다.")
   @PutMapping("/delete/{boardId}")
   public ResponseEntity<String> deleteBoard(@PathVariable Long boardId) {
@@ -69,7 +148,25 @@ public class BoardController {
       return ResponseEntity.badRequest().body("게시판 삭제 중 오류가 발생하였습니다 : " + e.getMessage());
     }
   }
+  */
 
+  @Operation(summary = "게시판 수정", description = "선택한 게시판의 제목, 설명을 수정할 수 있습니다.")
+  @PutMapping("/{boardId}")
+  public ApiResponse<Void> updateBoard(
+      @PathVariable Long boardId, @RequestBody UpdateBoardReqDto req) {
+    try {
+      boardFacade.updateBoard(boardId, req);
+
+      return ApiResponse.generateResp(Status.UPDATE, "게시판 수정이 완료되었습니다.", null);
+    } catch (CustomException e) {
+      Status status = Status.valueOf(e.getClass().getSimpleName().replace("Exception", "").toUpperCase());
+      return ApiResponse.generateResp(status, e.getMessage(), null);
+    } catch (Exception e) {
+      return ApiResponse.generateResp(Status.ERROR, "게시판 수정 중 오류가 발생하였습니다 : " + e.getMessage(), null);
+    }
+  }
+
+  /*
   @Operation(summary = "게시판 수정", description = "선택한 게시판의 제목, 설명을 수정할 수 있습니다.")
   @PutMapping("/{boardId}")
   public ResponseEntity<String> updateBoard(@PathVariable Long boardId, @RequestBody UpdateBoardReqDto req) {
@@ -81,4 +178,5 @@ public class BoardController {
       return ResponseEntity.badRequest().body("게시판 수정 중 오류가 발생하였습니다 : " + e.getMessage());
     }
   }
+  */
 }

--- a/src/main/java/com/pawstime/pawstime/domain/board/dto/req/CreateBoardReqDto.java
+++ b/src/main/java/com/pawstime/pawstime/domain/board/dto/req/CreateBoardReqDto.java
@@ -2,6 +2,7 @@ package com.pawstime.pawstime.domain.board.dto.req;
 
 import com.pawstime.pawstime.domain.board.entity.Board;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 
 public record CreateBoardReqDto(
     @Schema(description = "게시판 제목", example = "일상 게시판")

--- a/src/main/java/com/pawstime/pawstime/domain/board/dto/req/UpdateBoardReqDto.java
+++ b/src/main/java/com/pawstime/pawstime/domain/board/dto/req/UpdateBoardReqDto.java
@@ -1,7 +1,14 @@
 package com.pawstime.pawstime.domain.board.dto.req;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record UpdateBoardReqDto(
+    @Schema(description = "변경하고자 하는 게시판 제목",
+            example = "변경하고자하는 게시판 제목(입력하지 않을 경우 기존값 그대로 유지)")
     String title,
+
+    @Schema(description = "변경하고자 하는 게시판 설명",
+            example = "변경하고자하는 게시판 설명(입력하지 않을 경우 기존값 그대로 유지)")
     String description
 ) {
 

--- a/src/main/java/com/pawstime/pawstime/domain/board/dto/resp/GetBoardRespDto.java
+++ b/src/main/java/com/pawstime/pawstime/domain/board/dto/resp/GetBoardRespDto.java
@@ -1,6 +1,7 @@
 package com.pawstime.pawstime.domain.board.dto.resp;
 
 import com.pawstime.pawstime.domain.board.entity.Board;
+import java.time.LocalDateTime;
 import lombok.Builder;
 
 @Builder
@@ -8,7 +9,9 @@ public record GetBoardRespDto(
     Long boardId,
     String title,
     String description,
-    boolean isDelete
+    boolean isDelete,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt
 ) {
 
   public static GetBoardRespDto from(Board board) {
@@ -17,6 +20,8 @@ public record GetBoardRespDto(
         .title(board.getTitle())
         .description(board.getDescription())
         .isDelete(board.isDelete())
+        .createdAt(board.getCreatedAt())
+        .updatedAt(board.getUpdatedAt())
         .build();
   }
 }

--- a/src/main/java/com/pawstime/pawstime/domain/board/facade/BoardFacade.java
+++ b/src/main/java/com/pawstime/pawstime/domain/board/facade/BoardFacade.java
@@ -6,7 +6,9 @@ import com.pawstime.pawstime.domain.board.dto.resp.GetBoardRespDto;
 import com.pawstime.pawstime.domain.board.entity.Board;
 import com.pawstime.pawstime.domain.board.service.CreateBoardService;
 import com.pawstime.pawstime.domain.board.service.ReadBoardService;
-import java.util.List;
+import com.pawstime.pawstime.global.exception.DuplicateException;
+import com.pawstime.pawstime.global.exception.InvalidException;
+import com.pawstime.pawstime.global.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -26,10 +28,14 @@ public class BoardFacade {
   private final CreateBoardService createBoardService;
 
   public void createBoard(CreateBoardReqDto req) {
+    if (req.title() == null) {
+      throw new InvalidException("게시판 제목은 필수 입력값입니다.");
+    }
+
     Board existingBoard = readBoardService.findByTitle(req.title());
 
     if (existingBoard != null) {
-      throw new RuntimeException("이미 존재하는 게시판입니다.");
+      throw new DuplicateException("이미 존재하는 게시판입니다.");
     }
 
     createBoardService.createBoard(req.of());
@@ -39,7 +45,7 @@ public class BoardFacade {
     Board board = readBoardService.findById(boardId);
 
     if (board == null) {
-      throw new RuntimeException("해당 ID의 게시판은 존재하지 않습니다.");
+      throw new NotFoundException("존재하지 않는 게시판 ID입니다.");
     }
 
     return GetBoardRespDto.from(board);
@@ -56,10 +62,10 @@ public class BoardFacade {
     Board board = readBoardService.findById(boardId);
 
     if (board == null) {
-      throw new RuntimeException("해당 ID의 게시판은 존재하지 않습니다.");
+      throw new NotFoundException("존재하지 않는 게시판 ID입니다.");
     }
     if (board.isDelete()) {
-      throw new RuntimeException("이미 삭제된 게시판입니다.");
+      throw new NotFoundException("이미 삭제된 게시판입니다.");
     }
 
     board.softDelete();
@@ -71,10 +77,10 @@ public class BoardFacade {
     Board board = readBoardService.findById(boardId);
 
     if (board == null) {
-      throw new RuntimeException("해당 ID의 게시판은 존재하지 않습니다.");
+      throw new NotFoundException("존재하지 않는 게시판 ID입니다.");
     }
     if (board.isDelete()) {
-      throw new RuntimeException("이미 삭제된 게시판입니다.");
+      throw new NotFoundException("이미 삭제된 게시판입니다.");
     }
 
     // 요청 받은 title이 비어있지 않으면 기존의 제목을 수정하고,
@@ -84,7 +90,7 @@ public class BoardFacade {
 
       // 이미 동일한 제목을 사용하는 게시판이 존재하는지 확인
       if (existingBoard != null && !existingBoard.getBoardId().equals(boardId)) {
-        throw new RuntimeException("이미 존재하는 게시판입니다.");
+        throw new DuplicateException("이미 존재하는 게시판입니다.");
       }
 
       board.updateTitle(req.title());

--- a/src/main/java/com/pawstime/pawstime/global/common/ApiResponse.java
+++ b/src/main/java/com/pawstime/pawstime/global/common/ApiResponse.java
@@ -1,0 +1,24 @@
+package com.pawstime.pawstime.global.common;
+
+import com.pawstime.pawstime.global.enums.Status;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+public class ApiResponse<T> {
+
+  private Status status;
+  private String message;
+  private T data;
+
+  public ApiResponse(Status status, String message, T data) {
+    this.status = status;
+    this.message = message;
+    this.data = data;
+  }
+
+  public static <T> ApiResponse<T> generateResp(Status status, String message, T data) {
+    return new ApiResponse<>(status, message, data);
+  }
+}

--- a/src/main/java/com/pawstime/pawstime/global/enums/Status.java
+++ b/src/main/java/com/pawstime/pawstime/global/enums/Status.java
@@ -1,0 +1,31 @@
+package com.pawstime.pawstime.global.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum Status {
+
+  // 성공 상태
+  SUCCESS("Success", "요청이 성공적으로 처리된 경우"),
+  CREATE("Create", "리소스가 성공적으로 생성된 경우"),
+  UPDATE("Update", "리소스가 성공적으로 수정된 경우"),
+  DELETE("Delete", "리소스가 성공적으로 삭제된 경우"),
+
+  // 실패 상태
+  INVALID("Invalid", "요청 데이터가 잘못된 경우"),
+  DUPLICATE("Duplicate", "이미 존재하는 데이터로 새롭게 생성하려는 경우"),
+  NOTFOUND("Not Found", "요청한 리소스가 존재하지 않는 경우"),
+  UNAUTHORIZED("Unauthorized", "인증되지 않은 사용자가 접근하려는 경우"),
+  FORBIDDEN("Forbidden", "인증은 되었지만 권한이 없는 경우"),
+
+  // 에러 상태
+  ERROR("Error", "예상치 못한 예외가 발생한 경우");
+
+  private final String code;
+  private final String description;
+
+  Status(String code, String description) {
+    this.code = code;
+    this.description = description;
+  }
+}

--- a/src/main/java/com/pawstime/pawstime/global/exception/CustomException.java
+++ b/src/main/java/com/pawstime/pawstime/global/exception/CustomException.java
@@ -1,0 +1,8 @@
+package com.pawstime.pawstime.global.exception;
+
+public class CustomException extends RuntimeException{
+
+  public CustomException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/pawstime/pawstime/global/exception/DuplicateException.java
+++ b/src/main/java/com/pawstime/pawstime/global/exception/DuplicateException.java
@@ -1,0 +1,8 @@
+package com.pawstime.pawstime.global.exception;
+
+public class DuplicateException extends CustomException {
+
+  public DuplicateException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/pawstime/pawstime/global/exception/InvalidException.java
+++ b/src/main/java/com/pawstime/pawstime/global/exception/InvalidException.java
@@ -1,0 +1,8 @@
+package com.pawstime.pawstime.global.exception;
+
+public class InvalidException extends CustomException {
+
+  public InvalidException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/pawstime/pawstime/global/exception/NotFoundException.java
+++ b/src/main/java/com/pawstime/pawstime/global/exception/NotFoundException.java
@@ -1,0 +1,6 @@
+package com.pawstime.pawstime.global.exception;
+
+public class NotFoundException extends CustomException {
+
+  public NotFoundException(String message) {  super(message);  }
+}


### PR DESCRIPTION
## 📝 설명 (Description)
API 응답 구조를 통일하기 위해 이를 정의하고, 게시판 엔티티에 적용했습니다.

--- 

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:
- [x] 변경사항 1 : ApiResponse 클래스 생성: 모든 API 응답에 통일된 구조를 제공하기 위해 ApiResponse 클래스를 추가했습니다.
- [x] 변경사항 2 : Status enum 생성: 응답 상태를 세분화하여 나누고, 이를 편하게 관리하기 위해 enum 타입으로 생성했습니다.
- [x] 변경사항 3 : 커스텀 예외 생성: 각 예외에 맞는 커스텀 예외를 정의하여 응답 상태에 따른 적절한 예외 처리를 할 수 있도록 구현했습니다.

---

## 📌 참고 사항 (Additional Notes)
ApiResponse는 status, message, data로 구성되어 있으며, 각 상태에 맞는 응답을 제공합니다.
status : SUCCESS, CREATE, UPDATE, DELETE, INVALID, DUPLICATE, NOTFOUND, UNAUTHORIZED, FORBIDDEN, ERROR