### PR TITLE
refactor: 게시글 조회 쿼리의 sort 파라미터 처리 방식 개선

### DIFF
--- a/src/main/java/com/pawstime/pawstime/domain/post/entity/repository/PostRepository.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/entity/repository/PostRepository.java
@@ -1,52 +1,46 @@
 package com.pawstime.pawstime.domain.post.entity.repository;
 
 import com.pawstime.pawstime.domain.post.entity.Post;
-import org.apache.ibatis.annotations.Param;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+
 import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
-    // 모든 게시판의 모든 게시글 조회 (삭제되지 않은 게시글만 조회)
-    Page<Post> findByIsDeleteFalse(Pageable pageable);
 
-    // 특정 게시판의 게시글 조회 (삭제되지 않은 게시글만)
-    Page<Post> findByBoard_boardIdAndIsDeleteFalse(Long boardId, Pageable pageable);
+        // 게시글 조회 (기본 정렬은 작성일 기준 최신순, isDelete가 false인 게시글만 조회)
+        @Query("SELECT p FROM Post p WHERE p.isDelete = false ORDER BY p.createdAt DESC")
+        Page<Post> findAllActivePosts(Pageable pageable);
 
-    // 제목과 내용에서 검색 (삭제되지 않은 게시글만)
-    Page<Post> findByTitleContainingOrContentContainingAndIsDeleteFalse(String titleKeyword, String contentKeyword, Pageable pageable);
+        // 특정 게시판에서 게시글 조회 (isDelete가 false인 게시글만 조회)
+        @Query("SELECT p FROM Post p WHERE p.isDelete = false AND p.board.boardId = :boardId ORDER BY p.createdAt DESC")
+        Page<Post> findByBoardIdAndActive(Long boardId, Pageable pageable);
 
-    // 제목과 내용에서 검색 (특정 게시판, 삭제되지 않은 게시글만)
-    Page<Post> findByTitleContainingOrContentContainingAndBoard_boardIdAndIsDeleteFalse(
-            String titleKeyword, String contentKeyword, Long boardId, Pageable pageable);
+        // 제목 또는 내용으로 검색 (isDelete가 false인 게시글만 조회)
+        @Query("SELECT p FROM Post p WHERE p.isDelete = false " +
+                "AND (LOWER(p.title) LIKE LOWER(CONCAT('%', :keyword, '%')) OR LOWER(p.content) LIKE LOWER(CONCAT('%', :keyword, '%'))) " +
+                "AND (:boardId IS NULL OR p.board.boardId = :boardId) ORDER BY p.createdAt DESC")
+        Page<Post> findByKeywordAndBoardId(String keyword, Long boardId, Pageable pageable);
 
-    // 제목과 내용에서 검색 (특정 게시판, 삭제되지 않은 게시글만) - 수정
-    @Query("SELECT p FROM Post p WHERE p.board.boardId = :boardId AND p.isDelete = false " +
-            "AND (p.title LIKE %:titleKeyword% OR p.content LIKE %:contentKeyword%)")
-    Page<Post> findByBoardIdAndIsDeleteFalseAndTitleContainingOrContentContaining(
-            @Param("boardId") Long boardId,
-            @Param("titleKeyword") String titleKeyword,
-            @Param("contentKeyword") String contentKeyword,
-            Pageable pageable);
+    @Query("SELECT p FROM Post p WHERE p.isDelete = false " +
+            "AND (:boardId IS NULL OR p.board.boardId = :boardId) " +
+            "AND (:keyword IS NULL OR LOWER(p.title) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+            "OR LOWER(p.content) LIKE LOWER(CONCAT('%', :keyword, '%'))) " +
+            "ORDER BY " +
+            "CASE WHEN :sort = 'createdAt' THEN p.createdAt " +
+            "     WHEN :sort = 'views' THEN p.views " +
+            "     WHEN :sort = 'title' THEN p.title " +
+            "     ELSE p.createdAt END DESC")
+    Page<Post> findByBoardIdAndKeywordAndIsDeleted(Long boardId, String keyword, String sort, Pageable pageable);
 
-    // 최신순 (작성일 기준, 삭제되지 않은 게시글만)
-    Page<Post> findAllByIsDeleteFalseOrderByCreatedAtDesc(Pageable pageable);
 
-    // 조회수 기준 내림차순 (삭제되지 않은 게시글만)
-    Page<Post> findAllByIsDeleteFalseOrderByViewsDesc(Pageable pageable);
 
-    // 가나다순 (제목 기준, 삭제되지 않은 게시글만)
-    Page<Post> findAllByIsDeleteFalseOrderByTitleAsc(Pageable pageable);
 
-    // 제목으로 게시글 조회 (삭제된 게시글 제외)
-    Post findByTitle(String title);
-
-    // 특정 게시글 조회 (삭제되지 않은 게시글만)
-    // 특정 게시글 조회 (삭제되지 않은 게시글만)
-    Optional<Post> findByPostIdAndIsDeleteFalse(Long postId);
 
 }
+
+

--- a/src/main/java/com/pawstime/pawstime/domain/post/facade/PostFacade.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/facade/PostFacade.java
@@ -65,43 +65,8 @@ public class PostFacade {
     Post post = readPostService.findPostId(postId);
     return getDetailPostService.getDetailPost(postId);  // DTO 반환
   }
-
-  public Page<GetListPostRespDto> getPosts(Long boardId, String titleKeyword, String contentKeyword, String sortBy, Pageable pageable) {
-    Page<Post> posts;
-
-    // 제목과 내용에서 검색
-    if (titleKeyword != null || contentKeyword != null) {
-      posts = postRepository.findByTitleContainingOrContentContainingAndIsDeleteFalse(titleKeyword, contentKeyword, pageable);
-    } else if (boardId != null) {
-      // 게시판 ID 기준으로 게시글 조회
-      posts = postRepository.findByBoard_boardIdAndIsDeleteFalse(boardId, pageable);
-    } else {
-      // 정렬 기준에 맞춰 게시글 조회
-      switch (sortBy) {
-        case "views":
-          posts = postRepository.findAllByIsDeleteFalseOrderByViewsDesc(pageable); // 조회수 내림차순
-          break;
-        case "title":
-          posts = postRepository.findAllByIsDeleteFalseOrderByTitleAsc(pageable); // 가나다순
-          break;
-        case "latest":
-        default:
-          posts = postRepository.findAllByIsDeleteFalseOrderByCreatedAtDesc(pageable); // 최신순
-          break;
-      }
-    }
-
-    // 엔티티(Post)에서 DTO(GetListPostRespDto)로 변환하여 반환
-    return posts.map(post -> GetListPostRespDto.builder()
-            .id(post.getPostId())
-            .title(post.getTitle())
-            .contentPreview(post.getContent().length() > 100 ? post.getContent().substring(0, 100) + "..." : post.getContent())
-            .createdAt(post.getCreatedAt())
-            .updatedAt(post.getUpdatedAt())
-            .views(post.getViews())
-            .likesCount(post.getLikesCount())
-            .category(post.getCategory().name())
-            .build());
+  // 게시글 조회 요청 처리 (검색어, 게시판 ID, 페이지 번호, 페이지 크기)
+  public Page<Post> queryPosts(String keyword, Long boardId, int page, int size) {
+    return readPostService.readPosts(keyword, boardId, page, size);
   }
-
 }

--- a/src/main/java/com/pawstime/pawstime/domain/post/service/GetListPostService.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/service/GetListPostService.java
@@ -5,6 +5,7 @@ import com.pawstime.pawstime.domain.post.entity.Post;
 import com.pawstime.pawstime.domain.post.entity.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
@@ -13,50 +14,42 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class GetListPostService {
     private final PostRepository postRepository;
+    // 게시글 조회 (기본 정렬: 작성일 기준 최신순)
+    public Page<Post> getPosts(String keyword, Long boardId, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
 
-
-    public Page<GetListPostRespDto> getPostList(Pageable pageable, String searchKeyword, String sortBy, Long boardId) {
-        Page<Post> posts;
-
-        // 게시판 ID가 주어진 경우, 게시판 ID로 필터링 (삭제되지 않은 게시글만)
-        if (boardId != null) {
-            posts = postRepository.findByBoard_boardIdAndIsDeleteFalse(boardId, pageable);  // 삭제되지 않은 게시글만 조회
-        } else {
-            // 검색어가 있는 경우, 제목과 내용에서 검색 (삭제되지 않은 게시글만)
-            if (searchKeyword != null && !searchKeyword.isEmpty()) {
-                posts = postRepository.findByTitleContainingOrContentContainingAndIsDeleteFalse(
-                        searchKeyword, searchKeyword, pageable);  // 삭제되지 않은 게시글만 조회
-            } else {
-                // 정렬 기준에 맞춰 게시글 조회 (삭제되지 않은 게시글만)
-                switch (sortBy) {
-                    case "views":
-                        posts = postRepository.findAllByIsDeleteFalseOrderByViewsDesc(pageable);  // 조회수 내림차순
-                        break;
-                    case "title":
-                        posts = postRepository.findAllByIsDeleteFalseOrderByTitleAsc(pageable);  // 가나다순
-                        break;
-                    case "latest":
-                    default:
-                        posts = postRepository.findAllByIsDeleteFalseOrderByCreatedAtDesc(pageable);  // 최신순
-                        break;
-                }
-            }
+        // 검색어가 있을 경우
+        if (keyword != null && !keyword.isEmpty()) {
+            return postRepository.findByKeywordAndBoardId(keyword, boardId, pageable);
         }
 
-        // 엔티티(Post)에서 DTO(GetListPostRespDto)로 변환하여 반환
-        return posts.map(post -> GetListPostRespDto.builder()
-                .id(post.getPostId())
-                .title(post.getTitle())
-                .contentPreview(post.getContent().length() > 100
-                        ? post.getContent().substring(0, 100) + "..."
-                        : post.getContent())
-                .createdAt(post.getCreatedAt())
-                .updatedAt(post.getUpdatedAt())
-                .views(post.getViews())
-                .likesCount(post.getLikesCount())
-                .category(post.getCategory().name())
-                .build());
+        // 게시판 ID만 있을 경우
+        if (boardId != null) {
+            return postRepository.findByBoardIdAndActive(boardId, pageable);
+        }
+
+        // 기본 조회 (isDelete가 false인 게시글만)
+        return postRepository.findAllActivePosts(pageable);
     }
+    public Page<GetListPostRespDto> getPostList(Long boardId, String keyword, String sort, Pageable pageable) {
+        // sort 값이 null이거나 유효하지 않으면 기본값으로 'createdAt'을 사용
+        if (sort == null || (!sort.equals("createdAt") && !sort.equals("views") && !sort.equals("title"))) {
+            sort = "createdAt";  // 기본값 설정
+        }
+
+        // 동적 쿼리 호출 (isDelete가 true인 게시글은 제외)
+        Page<Post> posts = postRepository.findByBoardIdAndKeywordAndIsDeleted(boardId, keyword, sort, pageable);
+
+        // Page<Post>를 Page<GetListPostRespDto>로 변환하여 반환
+        return posts.map(GetListPostRespDto::from);
+    }
+
+
+
+
+
 }
+
+
 
 


### PR DESCRIPTION
## 📝 설명 (Description)
게시글 조회 쿼리에서 `sort` 파라미터 처리 방식을 개선하였습니다. <br>
`sort` 파라미터를 사용하여 게시글 정렬 방식에 대한 동적 쿼리를 더 유연하게 처리할 수 있도록 변경하였습니다.

--- 

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:
- [ ] 게시글 조회 쿼리에서 `sort` 파라미터를 처리하는 방식 개선.
- [ ] `PostRepository`에서 동적 쿼리를 통한 `sort` 처리 로직 수정.
- [ ] `service`에서 쿼리 파라미터 처리 방식 개선 및 테스트.

--- 

## 📌 참고 사항 (Additional Notes)
추가적인 설명이나 주의해야 할 사항이 있다면 적어주세요.<br>
- `PostRepository`의 쿼리 수정 후, 관련된 테스트가 필요합니다.
- `sort` 파라미터의 값에 따라 동적으로 쿼리가 처리되므로, 잘못된 값이 입력되면 예외가 발생할 수 있습니다.
