### PR TITLE
feat: createComment

### DIFF
--- a/src/main/java/com/pawstime/pawstime/domain/board/facade/BoardFacade.java
+++ b/src/main/java/com/pawstime/pawstime/domain/board/facade/BoardFacade.java
@@ -41,6 +41,7 @@ public class BoardFacade {
     createBoardService.createBoard(req.of());
   }
 
+  @Transactional(readOnly = true)
   public GetBoardRespDto getBoard(Long boardId) {
     Board board = readBoardService.findById(boardId);
 
@@ -51,6 +52,7 @@ public class BoardFacade {
     return GetBoardRespDto.from(board);
   }
 
+  @Transactional(readOnly = true)
   public Page<GetBoardRespDto> getBoardList(int pageNo, int pageSize, String sortBy, String direction) {
 
     Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by(Sort.Direction.fromString(direction), sortBy));

--- a/src/main/java/com/pawstime/pawstime/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/pawstime/pawstime/domain/comment/controller/CommentController.java
@@ -1,0 +1,42 @@
+package com.pawstime.pawstime.domain.comment.controller;
+
+import com.pawstime.pawstime.domain.comment.dto.req.CreateCommentReqDto;
+import com.pawstime.pawstime.domain.comment.facade.CommentFacade;
+import com.pawstime.pawstime.global.common.ApiResponse;
+import com.pawstime.pawstime.global.enums.Status;
+import com.pawstime.pawstime.global.exception.CustomException;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@Tag(name = "Comment", description = "댓글 API")
+@RestController
+@RequestMapping("/{postId}")
+@RequiredArgsConstructor
+public class CommentController {
+
+  private final CommentFacade commentFacade;
+
+  @Operation(summary = "댓글 생성", description = "댓글 생성 기능")
+  @PostMapping("/comments")
+  public ApiResponse<Void> createComment(
+      @PathVariable Long postId, @RequestBody CreateCommentReqDto req) {
+    try {
+      commentFacade.createComment(postId, req);
+
+      return ApiResponse.generateResp(Status.CREATE, "댓글 생성이 완료되었습니다.", null);
+    } catch (CustomException e) {
+      Status status = Status.valueOf(e.getClass().getSimpleName().replace("Exception", "").toUpperCase());
+      return ApiResponse.generateResp(status, e.getMessage(), null);
+    } catch (Exception e) {
+      return ApiResponse.generateResp(Status.ERROR, "댓글 생성 중 오류가 발생하였습니다 : " + e.getMessage(), null);
+    }
+  }
+}

--- a/src/main/java/com/pawstime/pawstime/domain/comment/dto/req/CreateCommentReqDto.java
+++ b/src/main/java/com/pawstime/pawstime/domain/comment/dto/req/CreateCommentReqDto.java
@@ -1,0 +1,18 @@
+package com.pawstime.pawstime.domain.comment.dto.req;
+
+import com.pawstime.pawstime.domain.comment.entity.Comment;
+import com.pawstime.pawstime.domain.post.entity.Post;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record CreateCommentReqDto(
+    @Schema(description = "댓글 내용", example = "댓글 내용을 남겨주세요.")
+    String content
+) {
+
+  public Comment of(Post post) {
+    return Comment.builder()
+        .post(post)
+        .content(this.content)
+        .build();
+  }
+}

--- a/src/main/java/com/pawstime/pawstime/domain/comment/entity/Comment.java
+++ b/src/main/java/com/pawstime/pawstime/domain/comment/entity/Comment.java
@@ -1,0 +1,37 @@
+package com.pawstime.pawstime.domain.comment.entity;
+
+import com.pawstime.pawstime.domain.post.entity.Post;
+import com.pawstime.pawstime.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "comment")
+public class Comment extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "comment_id")
+  private Long commentId;
+
+  private String content;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "post_id")
+  private Post post;
+}

--- a/src/main/java/com/pawstime/pawstime/domain/comment/entity/repository/CommentRepository.java
+++ b/src/main/java/com/pawstime/pawstime/domain/comment/entity/repository/CommentRepository.java
@@ -1,0 +1,14 @@
+package com.pawstime.pawstime.domain.comment.entity.repository;
+
+import com.pawstime.pawstime.domain.comment.entity.Comment;
+import com.pawstime.pawstime.domain.post.entity.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+  @Query("SELECT p FROM Post p WHERE p.postId = :postId AND p.isDelete = false")
+  Post findByIdQuery(Long postId);
+}

--- a/src/main/java/com/pawstime/pawstime/domain/comment/facade/CommentFacade.java
+++ b/src/main/java/com/pawstime/pawstime/domain/comment/facade/CommentFacade.java
@@ -1,0 +1,37 @@
+package com.pawstime.pawstime.domain.comment.facade;
+
+import com.pawstime.pawstime.domain.comment.dto.req.CreateCommentReqDto;
+import com.pawstime.pawstime.domain.comment.service.CreateCommentService;
+import com.pawstime.pawstime.domain.comment.service.ReadCommentService;
+import com.pawstime.pawstime.domain.post.entity.Post;
+import com.pawstime.pawstime.global.exception.InvalidException;
+import com.pawstime.pawstime.global.exception.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Transactional
+@Component
+@RequiredArgsConstructor
+public class CommentFacade {
+
+  private final ReadCommentService readCommentService;
+  private final CreateCommentService createCommentService;
+
+  public void createComment(Long postId, CreateCommentReqDto req) {
+    Post post = readCommentService.findByIdQuery(postId);
+
+    if (post == null) {
+      throw new NotFoundException("존재하지 않는 게시글 ID입니다.");
+      // isDelete = true로 삭제된 게시글도 여기에 걸림.
+    }
+
+    if (req.content() == null) {
+      throw new InvalidException("댓글 내용은 필수 입력값입니다.");
+    }
+
+    createCommentService.createComment(req.of(post));
+  }
+}

--- a/src/main/java/com/pawstime/pawstime/domain/comment/service/CreateCommentService.java
+++ b/src/main/java/com/pawstime/pawstime/domain/comment/service/CreateCommentService.java
@@ -1,0 +1,17 @@
+package com.pawstime.pawstime.domain.comment.service;
+
+import com.pawstime.pawstime.domain.comment.entity.Comment;
+import com.pawstime.pawstime.domain.comment.entity.repository.CommentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CreateCommentService {
+
+  private final CommentRepository commentRepository;
+
+  public void createComment(Comment comment) {
+    commentRepository.save(comment);
+  }
+}

--- a/src/main/java/com/pawstime/pawstime/domain/comment/service/ReadCommentService.java
+++ b/src/main/java/com/pawstime/pawstime/domain/comment/service/ReadCommentService.java
@@ -1,0 +1,17 @@
+package com.pawstime.pawstime.domain.comment.service;
+
+import com.pawstime.pawstime.domain.comment.entity.repository.CommentRepository;
+import com.pawstime.pawstime.domain.post.entity.Post;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ReadCommentService {
+
+  private final CommentRepository commentRepository;
+
+  public Post findByIdQuery(Long postId) {
+    return commentRepository.findByIdQuery(postId);
+  }
+}

--- a/src/main/java/com/pawstime/pawstime/global/config/web/WebConfig.java
+++ b/src/main/java/com/pawstime/pawstime/global/config/web/WebConfig.java
@@ -10,7 +10,7 @@ public class WebConfig implements WebMvcConfigurer {
   @Override
   public void addCorsMappings(CorsRegistry registry) {
     registry.addMapping("/**")
-        .allowedOrigins("http://43.200.46.13:8080")  // 프론트엔드 주소
+        .allowedOrigins("http://43.200.46.13:8080", "http://43.200.46.13:3000")
         .allowedMethods("GET", "POST", "PUT", "DELETE")
         .allowedHeaders("*");
 


### PR DESCRIPTION
## 📝 설명 (Description)
댓글 생성 기능을 구현했습니다. 
사용자는 게시글 id, 댓글 내용을 입력하면 해당 게시글에 댓글을 달 수 있습니다.

--- 

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:
- [x] 변경사항 1 : Comment 엔티티 추가 - postId와 content 필드를 가진 Comment 엔티티 추가
- [x] 변경사항 2 : 게시글 유효성 검사 - 댓글 생성 요청 시, 게시글이 존재하고 삭제되지 않았는지 확인 후 댓글 작성이 가능하도록 처리
- [x] 변경사항 3 : BoardFacade에서 조회만 하는 메서드에 readonly = true 설정.

---

## 📌 참고 사항 (Additional Notes)
추후 유저 기능이 구현되면 로그인한 유저만 댓글 작성이 가능하도록 구현할 예정입니다.
