### PR TITLE
feat: 댓글 전체 목록 조회 기능 구현

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
 
   # Spring Boot 애플리케이션 서비스
   springboot:
-    image: dgf0020/pawstime:1.0.1
+    image: dgf0020/pawstime:1.1.3
     container_name: springboot_app
     restart: always
     environment:

--- a/src/main/java/com/pawstime/pawstime/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/pawstime/pawstime/domain/comment/controller/CommentController.java
@@ -9,23 +9,25 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @Tag(name = "Comment", description = "댓글 API")
 @RestController
-@RequestMapping("/{postId}")
+@RequestMapping("/comments")
 @RequiredArgsConstructor
 public class CommentController {
 
   private final CommentFacade commentFacade;
 
-  @Operation(summary = "댓글 생성", description = "댓글 생성 기능")
-  @PostMapping("/comments")
+  @Operation(summary = "댓글 생성", description = "특정 게시글에 댓글을 생성하는 기능입니다.")
+  @PostMapping("/{postId}")
   public ApiResponse<Void> createComment(
       @PathVariable Long postId, @RequestBody CreateCommentReqDto req) {
     try {
@@ -37,6 +39,24 @@ public class CommentController {
       return ApiResponse.generateResp(status, e.getMessage(), null);
     } catch (Exception e) {
       return ApiResponse.generateResp(Status.ERROR, "댓글 생성 중 오류가 발생하였습니다 : " + e.getMessage(), null);
+    }
+  }
+
+  @Operation(summary = "댓글 전체 목록 조회", description = "모든 게시글에 달린 댓글을 조회합니다.")
+  @GetMapping("/listAll")
+  public ApiResponse<?> getCommentAll(
+      @RequestParam(defaultValue = "0") int pageNo,
+      @RequestParam(defaultValue = "10") int pageSize,
+      @RequestParam(defaultValue = "createdAt") String sortBy,
+      @RequestParam(defaultValue = "DESC") String direction
+  ) {
+    try {
+      return ApiResponse.generateResp(Status.SUCCESS, null, commentFacade.getCommentAll(pageNo, pageSize, sortBy, direction).getContent());
+    } catch (CustomException e) {
+      Status status = Status.valueOf(e.getClass().getSimpleName().replace("Exception", "").toUpperCase());
+      return ApiResponse.generateResp(status, e.getMessage(), null);
+    } catch (Exception e) {
+      return ApiResponse.generateResp(Status.ERROR, "전체 댓글 조회 중 오류가 발생하였습니다 : " + e.getMessage(), null);
     }
   }
 }

--- a/src/main/java/com/pawstime/pawstime/domain/comment/dto/resp/GetCommentRespDto.java
+++ b/src/main/java/com/pawstime/pawstime/domain/comment/dto/resp/GetCommentRespDto.java
@@ -1,0 +1,26 @@
+package com.pawstime.pawstime.domain.comment.dto.resp;
+
+import com.pawstime.pawstime.domain.board.dto.resp.GetBoardRespDto;
+import com.pawstime.pawstime.domain.comment.entity.Comment;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record GetCommentRespDto(
+    Long commentId,
+    String content,
+    Long postId,
+    LocalDateTime createAt,
+    LocalDateTime updateAt
+) {
+
+  public static GetCommentRespDto from(Comment comment) {
+    return GetCommentRespDto.builder()
+        .commentId(comment.getCommentId())
+        .content(comment.getContent())
+        .postId(comment.getPost().getPostId())
+        .createAt(comment.getCreatedAt())
+        .updateAt(comment.getUpdatedAt())
+        .build();
+  }
+}

--- a/src/main/java/com/pawstime/pawstime/domain/comment/entity/repository/CommentRepository.java
+++ b/src/main/java/com/pawstime/pawstime/domain/comment/entity/repository/CommentRepository.java
@@ -2,6 +2,8 @@ package com.pawstime.pawstime.domain.comment.entity.repository;
 
 import com.pawstime.pawstime.domain.comment.entity.Comment;
 import com.pawstime.pawstime.domain.post.entity.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -11,4 +13,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
   @Query("SELECT p FROM Post p WHERE p.postId = :postId AND p.isDelete = false")
   Post findByIdQuery(Long postId);
+
+  @Query("SELECT c FROM Comment c WHERE c.isDelete = false")
+  Page<Comment> findAllQuery(Pageable pageable);
 }

--- a/src/main/java/com/pawstime/pawstime/domain/comment/facade/CommentFacade.java
+++ b/src/main/java/com/pawstime/pawstime/domain/comment/facade/CommentFacade.java
@@ -1,6 +1,7 @@
 package com.pawstime.pawstime.domain.comment.facade;
 
 import com.pawstime.pawstime.domain.comment.dto.req.CreateCommentReqDto;
+import com.pawstime.pawstime.domain.comment.dto.resp.GetCommentRespDto;
 import com.pawstime.pawstime.domain.comment.service.CreateCommentService;
 import com.pawstime.pawstime.domain.comment.service.ReadCommentService;
 import com.pawstime.pawstime.domain.post.entity.Post;
@@ -8,6 +9,10 @@ import com.pawstime.pawstime.global.exception.InvalidException;
 import com.pawstime.pawstime.global.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,5 +38,11 @@ public class CommentFacade {
     }
 
     createCommentService.createComment(req.of(post));
+  }
+
+  @Transactional(readOnly = true)
+  public Page<?> getCommentAll(int pageNo, int pageSize, String sortBy, String direction) {
+    Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by(Sort.Direction.fromString(direction), sortBy));
+    return readCommentService.getCommentAll(pageable).map(GetCommentRespDto::from);
   }
 }

--- a/src/main/java/com/pawstime/pawstime/domain/comment/service/ReadCommentService.java
+++ b/src/main/java/com/pawstime/pawstime/domain/comment/service/ReadCommentService.java
@@ -1,8 +1,12 @@
 package com.pawstime.pawstime.domain.comment.service;
 
+import com.pawstime.pawstime.domain.comment.entity.Comment;
 import com.pawstime.pawstime.domain.comment.entity.repository.CommentRepository;
 import com.pawstime.pawstime.domain.post.entity.Post;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -13,5 +17,9 @@ public class ReadCommentService {
 
   public Post findByIdQuery(Long postId) {
     return commentRepository.findByIdQuery(postId);
+  }
+
+  public Page<Comment> getCommentAll(Pageable pageable) {
+    return commentRepository.findAllQuery(pageable);
   }
 }

--- a/src/main/java/com/pawstime/pawstime/global/config/web/WebConfig.java
+++ b/src/main/java/com/pawstime/pawstime/global/config/web/WebConfig.java
@@ -10,7 +10,7 @@ public class WebConfig implements WebMvcConfigurer {
   @Override
   public void addCorsMappings(CorsRegistry registry) {
     registry.addMapping("/**")
-        .allowedOrigins("http://43.200.46.13:8080", "http://43.200.46.13:3000")
+        .allowedOrigins("*")
         .allowedMethods("GET", "POST", "PUT", "DELETE")
         .allowedHeaders("*");
 


### PR DESCRIPTION
## 📝 설명 (Description)
전체 댓글 목록을 조회하는 기능을 구현했습니다.

--- 

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:
- [x] 변경사항 1 : 댓글 조회에 페이지네이션 추가 - 댓글이 많을 경우에도 효율적으로 데이터를 가져올 수 있도록 페이지네이션 기능을 추가하였습니다.
- [x] 변경사항 2 : @Query 어노테이션을 사용하여 전체 댓글 조회 시 논리 삭제된 댓글을 제외하도록 처리했습니다. (isDelete = false인 댓글만 조회됩니다.)

---

## 📌 참고 사항 (Additional Notes)
다음 단계로 특정 게시글에 대한 댓글만 조회할 수 있는 기능 구현 예정입니다.
