### PR TITLE
fix: httpStatus 응답코드 수정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
 
   # Spring Boot 애플리케이션 서비스
   springboot:
-    image: dgf0020/pawstime:1.0.1
+    image: dgf0020/pawstime:1.1.3
     container_name: springboot_app
     restart: always
     environment:

--- a/src/main/java/com/pawstime/pawstime/domain/board/controller/BoardController.java
+++ b/src/main/java/com/pawstime/pawstime/domain/board/controller/BoardController.java
@@ -13,6 +13,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -34,8 +35,7 @@ public class BoardController {
 
   @Operation(summary = "게시판 생성", description = "새로운 게시판을 생성할 수 있습니다.")
   @PostMapping("/boards")
-  @ResponseStatus(HttpStatus.CREATED)
-  public ApiResponse<Void> createBoard(@RequestBody CreateBoardReqDto req) {
+  public ResponseEntity<ApiResponse<Void>> createBoard(@RequestBody CreateBoardReqDto req) {
     try {
       boardFacade.createBoard(req);
 
@@ -67,8 +67,7 @@ public class BoardController {
   @Operation(summary = "게시판 상세 조회",
       description = "board_id를 입력하면 title, description을 조회할 수 있습니다.")
   @GetMapping("/{boardId}")
-  @ResponseStatus(HttpStatus.OK)
-  public ApiResponse<GetBoardRespDto> getBoard(@PathVariable Long boardId) {
+  public ResponseEntity<ApiResponse<GetBoardRespDto>> getBoard(@PathVariable Long boardId) {
     try {
       return ApiResponse.generateResp(Status.SUCCESS, null, boardFacade.getBoard(boardId));
     } catch (CustomException e) {
@@ -90,7 +89,7 @@ public class BoardController {
 
   @Operation(summary = "게시판 목록 조회", description = "생성되어있는 모든 게시판을 조회합니다.")
   @GetMapping("/list")
-  public ApiResponse<List<GetBoardRespDto>> getBoardList(
+  public ResponseEntity<ApiResponse<List<GetBoardRespDto>>> getBoardList(
       @RequestParam(defaultValue = "0") int pageNo,
       @RequestParam(defaultValue = "10") int pageSize,
       @RequestParam(defaultValue = "createdAt") String sortBy,
@@ -123,7 +122,7 @@ public class BoardController {
 
   @Operation(summary = "게시판 삭제", description = "선택한 게시판을 삭제합니다.")
   @PutMapping("/delete/{boardId}")
-  public ApiResponse<Void> deleteBoard(@PathVariable Long boardId) {
+  public ResponseEntity<ApiResponse<Void>> deleteBoard(@PathVariable Long boardId) {
     try {
       boardFacade.deleteBoard(boardId);
 
@@ -152,7 +151,7 @@ public class BoardController {
 
   @Operation(summary = "게시판 수정", description = "선택한 게시판의 제목, 설명을 수정할 수 있습니다.")
   @PutMapping("/{boardId}")
-  public ApiResponse<Void> updateBoard(
+  public ResponseEntity<ApiResponse<Void>> updateBoard(
       @PathVariable Long boardId, @RequestBody UpdateBoardReqDto req) {
     try {
       boardFacade.updateBoard(boardId, req);

--- a/src/main/java/com/pawstime/pawstime/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/pawstime/pawstime/domain/comment/controller/CommentController.java
@@ -1,14 +1,18 @@
 package com.pawstime.pawstime.domain.comment.controller;
 
 import com.pawstime.pawstime.domain.comment.dto.req.CreateCommentReqDto;
+import com.pawstime.pawstime.domain.comment.dto.resp.GetCommentRespDto;
 import com.pawstime.pawstime.domain.comment.facade.CommentFacade;
 import com.pawstime.pawstime.global.common.ApiResponse;
 import com.pawstime.pawstime.global.enums.Status;
 import com.pawstime.pawstime.global.exception.CustomException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -28,7 +32,7 @@ public class CommentController {
 
   @Operation(summary = "댓글 생성", description = "특정 게시글에 댓글을 생성하는 기능입니다.")
   @PostMapping("/{postId}")
-  public ApiResponse<Void> createComment(
+  public ResponseEntity<ApiResponse<Void>> createComment(
       @PathVariable Long postId, @RequestBody CreateCommentReqDto req) {
     try {
       commentFacade.createComment(postId, req);
@@ -44,7 +48,7 @@ public class CommentController {
 
   @Operation(summary = "댓글 전체 목록 조회", description = "모든 게시글에 달린 댓글을 조회합니다.")
   @GetMapping("/listAll")
-  public ApiResponse<?> getCommentAll(
+  public ResponseEntity<ApiResponse<List<GetCommentRespDto>>> getCommentAll(
       @RequestParam(defaultValue = "0") int pageNo,
       @RequestParam(defaultValue = "10") int pageSize,
       @RequestParam(defaultValue = "createdAt") String sortBy,

--- a/src/main/java/com/pawstime/pawstime/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/pawstime/pawstime/domain/comment/controller/CommentController.java
@@ -9,23 +9,25 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @Tag(name = "Comment", description = "댓글 API")
 @RestController
-@RequestMapping("/{postId}")
+@RequestMapping("/comments")
 @RequiredArgsConstructor
 public class CommentController {
 
   private final CommentFacade commentFacade;
 
-  @Operation(summary = "댓글 생성", description = "댓글 생성 기능")
-  @PostMapping("/comments")
+  @Operation(summary = "댓글 생성", description = "특정 게시글에 댓글을 생성하는 기능입니다.")
+  @PostMapping("/{postId}")
   public ApiResponse<Void> createComment(
       @PathVariable Long postId, @RequestBody CreateCommentReqDto req) {
     try {
@@ -37,6 +39,24 @@ public class CommentController {
       return ApiResponse.generateResp(status, e.getMessage(), null);
     } catch (Exception e) {
       return ApiResponse.generateResp(Status.ERROR, "댓글 생성 중 오류가 발생하였습니다 : " + e.getMessage(), null);
+    }
+  }
+
+  @Operation(summary = "댓글 전체 목록 조회", description = "모든 게시글에 달린 댓글을 조회합니다.")
+  @GetMapping("/listAll")
+  public ApiResponse<?> getCommentAll(
+      @RequestParam(defaultValue = "0") int pageNo,
+      @RequestParam(defaultValue = "10") int pageSize,
+      @RequestParam(defaultValue = "createdAt") String sortBy,
+      @RequestParam(defaultValue = "DESC") String direction
+  ) {
+    try {
+      return ApiResponse.generateResp(Status.SUCCESS, null, commentFacade.getCommentAll(pageNo, pageSize, sortBy, direction).getContent());
+    } catch (CustomException e) {
+      Status status = Status.valueOf(e.getClass().getSimpleName().replace("Exception", "").toUpperCase());
+      return ApiResponse.generateResp(status, e.getMessage(), null);
+    } catch (Exception e) {
+      return ApiResponse.generateResp(Status.ERROR, "전체 댓글 조회 중 오류가 발생하였습니다 : " + e.getMessage(), null);
     }
   }
 }

--- a/src/main/java/com/pawstime/pawstime/domain/comment/dto/resp/GetCommentRespDto.java
+++ b/src/main/java/com/pawstime/pawstime/domain/comment/dto/resp/GetCommentRespDto.java
@@ -1,0 +1,26 @@
+package com.pawstime.pawstime.domain.comment.dto.resp;
+
+import com.pawstime.pawstime.domain.board.dto.resp.GetBoardRespDto;
+import com.pawstime.pawstime.domain.comment.entity.Comment;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record GetCommentRespDto(
+    Long commentId,
+    String content,
+    Long postId,
+    LocalDateTime createAt,
+    LocalDateTime updateAt
+) {
+
+  public static GetCommentRespDto from(Comment comment) {
+    return GetCommentRespDto.builder()
+        .commentId(comment.getCommentId())
+        .content(comment.getContent())
+        .postId(comment.getPost().getPostId())
+        .createAt(comment.getCreatedAt())
+        .updateAt(comment.getUpdatedAt())
+        .build();
+  }
+}

--- a/src/main/java/com/pawstime/pawstime/domain/comment/entity/repository/CommentRepository.java
+++ b/src/main/java/com/pawstime/pawstime/domain/comment/entity/repository/CommentRepository.java
@@ -2,6 +2,8 @@ package com.pawstime.pawstime.domain.comment.entity.repository;
 
 import com.pawstime.pawstime.domain.comment.entity.Comment;
 import com.pawstime.pawstime.domain.post.entity.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -11,4 +13,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
   @Query("SELECT p FROM Post p WHERE p.postId = :postId AND p.isDelete = false")
   Post findByIdQuery(Long postId);
+
+  @Query("SELECT c FROM Comment c WHERE c.isDelete = false")
+  Page<Comment> findAllQuery(Pageable pageable);
 }

--- a/src/main/java/com/pawstime/pawstime/domain/comment/facade/CommentFacade.java
+++ b/src/main/java/com/pawstime/pawstime/domain/comment/facade/CommentFacade.java
@@ -41,7 +41,7 @@ public class CommentFacade {
   }
 
   @Transactional(readOnly = true)
-  public Page<?> getCommentAll(int pageNo, int pageSize, String sortBy, String direction) {
+  public Page<GetCommentRespDto> getCommentAll(int pageNo, int pageSize, String sortBy, String direction) {
     Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by(Sort.Direction.fromString(direction), sortBy));
     return readCommentService.getCommentAll(pageable).map(GetCommentRespDto::from);
   }

--- a/src/main/java/com/pawstime/pawstime/domain/comment/facade/CommentFacade.java
+++ b/src/main/java/com/pawstime/pawstime/domain/comment/facade/CommentFacade.java
@@ -1,6 +1,7 @@
 package com.pawstime.pawstime.domain.comment.facade;
 
 import com.pawstime.pawstime.domain.comment.dto.req.CreateCommentReqDto;
+import com.pawstime.pawstime.domain.comment.dto.resp.GetCommentRespDto;
 import com.pawstime.pawstime.domain.comment.service.CreateCommentService;
 import com.pawstime.pawstime.domain.comment.service.ReadCommentService;
 import com.pawstime.pawstime.domain.post.entity.Post;
@@ -8,6 +9,10 @@ import com.pawstime.pawstime.global.exception.InvalidException;
 import com.pawstime.pawstime.global.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,5 +38,11 @@ public class CommentFacade {
     }
 
     createCommentService.createComment(req.of(post));
+  }
+
+  @Transactional(readOnly = true)
+  public Page<?> getCommentAll(int pageNo, int pageSize, String sortBy, String direction) {
+    Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by(Sort.Direction.fromString(direction), sortBy));
+    return readCommentService.getCommentAll(pageable).map(GetCommentRespDto::from);
   }
 }

--- a/src/main/java/com/pawstime/pawstime/domain/comment/service/ReadCommentService.java
+++ b/src/main/java/com/pawstime/pawstime/domain/comment/service/ReadCommentService.java
@@ -1,8 +1,12 @@
 package com.pawstime.pawstime.domain.comment.service;
 
+import com.pawstime.pawstime.domain.comment.entity.Comment;
 import com.pawstime.pawstime.domain.comment.entity.repository.CommentRepository;
 import com.pawstime.pawstime.domain.post.entity.Post;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -13,5 +17,9 @@ public class ReadCommentService {
 
   public Post findByIdQuery(Long postId) {
     return commentRepository.findByIdQuery(postId);
+  }
+
+  public Page<Comment> getCommentAll(Pageable pageable) {
+    return commentRepository.findAllQuery(pageable);
   }
 }

--- a/src/main/java/com/pawstime/pawstime/global/common/ApiResponse.java
+++ b/src/main/java/com/pawstime/pawstime/global/common/ApiResponse.java
@@ -1,9 +1,8 @@
 package com.pawstime.pawstime.global.common;
 
 import com.pawstime.pawstime.global.enums.Status;
-import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
+import org.springframework.http.ResponseEntity;
 
 @Getter
 public class ApiResponse<T> {
@@ -18,7 +17,8 @@ public class ApiResponse<T> {
     this.data = data;
   }
 
-  public static <T> ApiResponse<T> generateResp(Status status, String message, T data) {
-    return new ApiResponse<>(status, message, data);
+  public static <T> ResponseEntity<ApiResponse<T>> generateResp(Status status, String message, T data) {
+    ApiResponse<T> apiResponse =  new ApiResponse<>(status, message, data);
+    return ResponseEntity.status(status.getHttpStatus()).body(apiResponse);
   }
 }

--- a/src/main/java/com/pawstime/pawstime/global/config/web/WebConfig.java
+++ b/src/main/java/com/pawstime/pawstime/global/config/web/WebConfig.java
@@ -10,7 +10,7 @@ public class WebConfig implements WebMvcConfigurer {
   @Override
   public void addCorsMappings(CorsRegistry registry) {
     registry.addMapping("/**")
-        .allowedOrigins("http://43.200.46.13:8080", "http://43.200.46.13:3000")
+        .allowedOrigins("*")
         .allowedMethods("GET", "POST", "PUT", "DELETE")
         .allowedHeaders("*");
 

--- a/src/main/java/com/pawstime/pawstime/global/enums/Status.java
+++ b/src/main/java/com/pawstime/pawstime/global/enums/Status.java
@@ -1,31 +1,34 @@
 package com.pawstime.pawstime.global.enums;
 
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @Getter
 public enum Status {
 
   // 성공 상태
-  SUCCESS("Success", "요청이 성공적으로 처리된 경우"),
-  CREATE("Create", "리소스가 성공적으로 생성된 경우"),
-  UPDATE("Update", "리소스가 성공적으로 수정된 경우"),
-  DELETE("Delete", "리소스가 성공적으로 삭제된 경우"),
+  SUCCESS("Success", "요청이 성공적으로 처리된 경우", HttpStatus.OK),
+  CREATE("Create", "리소스가 성공적으로 생성된 경우", HttpStatus.CREATED),
+  UPDATE("Update", "리소스가 성공적으로 수정된 경우", HttpStatus.OK),
+  DELETE("Delete", "리소스가 성공적으로 삭제된 경우", HttpStatus.NO_CONTENT),
 
   // 실패 상태
-  INVALID("Invalid", "요청 데이터가 잘못된 경우"),
-  DUPLICATE("Duplicate", "이미 존재하는 데이터로 새롭게 생성하려는 경우"),
-  NOTFOUND("Not Found", "요청한 리소스가 존재하지 않는 경우"),
-  UNAUTHORIZED("Unauthorized", "인증되지 않은 사용자가 접근하려는 경우"),
-  FORBIDDEN("Forbidden", "인증은 되었지만 권한이 없는 경우"),
+  INVALID("Invalid", "요청 데이터가 잘못된 경우", HttpStatus.BAD_REQUEST),
+  DUPLICATE("Duplicate", "이미 존재하는 데이터로 새롭게 생성하려는 경우", HttpStatus.CONFLICT),
+  NOTFOUND("Not Found", "요청한 리소스가 존재하지 않는 경우", HttpStatus.NOT_FOUND),
+  UNAUTHORIZED("Unauthorized", "인증되지 않은 사용자가 접근하려는 경우", HttpStatus.UNAUTHORIZED),
+  FORBIDDEN("Forbidden", "인증은 되었지만 권한이 없는 경우", HttpStatus.FORBIDDEN),
 
   // 에러 상태
-  ERROR("Error", "예상치 못한 예외가 발생한 경우");
+  ERROR("Error", "예상치 못한 예외가 발생한 경우", HttpStatus.INTERNAL_SERVER_ERROR);
 
   private final String code;
   private final String description;
+  private final HttpStatus httpStatus;
 
-  Status(String code, String description) {
+  Status(String code, String description, HttpStatus httpStatus) {
     this.code = code;
     this.description = description;
+    this.httpStatus = httpStatus;
   }
 }


### PR DESCRIPTION
## 📝 설명 (Description)
API 응답 코드와 상태 처리를 개선한 작업입니다. 이전에는 실패한 요청에도 불구하고 HTTP 상태 코드가 200번대(성공)로 반환되는 문제가 있었습니다. 이를 해결하기 위해 ApiResponse의 Status를 기반으로 정확한 HTTP 상태 코드가 반환되도록 수정하였습니다. 이 변경으로 성공 및 실패 상태에 따라 적절한 HTTP 응답 코드가 전달됩니다.

--- 

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:
- [x] 변경사항 1 : Status enum에서 각 상태(SUCCESS, CREATE, INVALID, ERROR 등)에 대해 해당하는 HTTP 상태 코드를 매핑하여 정의하였습니다.
- [x] 변경사항 2 : 컨트롤러, ApiResponse 클래스에서 반환형을 ResponseEntity<>로 수정하여 Status에 맞는 HTTP 상태 코드가 적용되도록 변경하였습니다.

---

## 📌 참고 사항 (Additional Notes)
상황에 알맞은 코드로 응답코드가 반환되도록 수정하였습니다.
응답 코드 변경 후의 API 요청 결과 화면
![image](https://github.com/user-attachments/assets/cc0dadd8-09ab-4a2e-9818-c328a4bbf21c)
![image](https://github.com/user-attachments/assets/92659633-2b87-48ea-8910-900236dd853f)

