### PR TITLE
feat: 게시판 조회에서 삭제된 게시판 제외

### DIFF
--- a/src/main/java/com/pawstime/pawstime/domain/board/controller/BoardController.java
+++ b/src/main/java/com/pawstime/pawstime/domain/board/controller/BoardController.java
@@ -39,53 +39,44 @@ public class BoardController {
     try {
       boardFacade.createBoard(req);
 
-      return ApiResponse.generateResp(Status.CREATE, "게시판 생성이 완료되었습니다.", null);
+      return ApiResponse.generateResp(
+          Status.CREATE, "게시판 생성이 완료되었습니다.", null);
+
     } catch (CustomException e) {
-      Status status = Status.valueOf(e.getClass().getSimpleName().replace("Exception", "").toUpperCase());
+      Status status = Status.valueOf(e.getClass()
+          .getSimpleName()
+          .replace("Exception", "")
+          .toUpperCase());
       // 예외 이름을 이용해서 Enum타입의 Status를 가져옴. ex) InvalidException => INVALID
-      log.info("** {} **", status);
+      // log.info("** {} **", status);
       return ApiResponse.generateResp(status, e.getMessage(), null);
+
     } catch (Exception e) {
-      return ApiResponse.generateResp(Status.ERROR, "게시판 생성 중 오류가 발생하였습니다 : " + e.getMessage(), null);
+      return ApiResponse.generateResp(
+          Status.ERROR, "게시판 생성 중 오류가 발생하였습니다 : " + e.getMessage(), null);
     }
   }
-
-  /*
-  @Operation(summary = "게시판 생성", description = "새로운 게시판을 생성할 수 있습니다.")
-  @PostMapping("/boards")
-  public ResponseEntity<String> createBoard(@RequestBody CreateBoardReqDto req) {
-    try {
-      boardFacade.createBoard(req);
-
-      return ResponseEntity.ok().body("게시판 생성이 완료되었습니다.");
-    } catch (Exception e) {
-      return ResponseEntity.badRequest().body("게시판 생성 중 오류가 발생하였습니다 : " + e.getMessage());
-    }
-  }
-  */
 
   @Operation(summary = "게시판 상세 조회",
       description = "board_id를 입력하면 title, description을 조회할 수 있습니다.")
   @GetMapping("/{boardId}")
   public ResponseEntity<ApiResponse<GetBoardRespDto>> getBoard(@PathVariable Long boardId) {
     try {
-      return ApiResponse.generateResp(Status.SUCCESS, null, boardFacade.getBoard(boardId));
+      return ApiResponse.generateResp(
+          Status.SUCCESS, null, boardFacade.getBoard(boardId));
+
     } catch (CustomException e) {
-      Status status = Status.valueOf(e.getClass().getSimpleName().replace("Exception", "").toUpperCase());
+      Status status = Status.valueOf(e.getClass()
+          .getSimpleName()
+          .replace("Exception", "")
+          .toUpperCase());
       return ApiResponse.generateResp(status, e.getMessage(), null);
+
     } catch (Exception e) {
-      return ApiResponse.generateResp(Status.ERROR, "게시판 상세 조회 중 오류가 발생하였습니다 : " + e.getMessage(), null);
+      return ApiResponse.generateResp(
+          Status.ERROR, "게시판 상세조회 중 오류가 발생하였습니다 : " + e.getMessage(), null);
     }
   }
-
-  /*
-  @Operation(summary = "게시판 상세 조회",
-      description = "board_id를 입력하면 title, description을 조회할 수 있습니다.")
-  @GetMapping("/{boardId}")
-  public ResponseEntity<GetBoardRespDto> getBoard(@PathVariable Long boardId) {
-    return ResponseEntity.ok().body(boardFacade.getBoard(boardId));
-  }
-  */
 
   @Operation(summary = "게시판 목록 조회", description = "생성되어있는 모든 게시판을 조회합니다.")
   @GetMapping("/list")
@@ -98,27 +89,19 @@ public class BoardController {
     try {
       return ApiResponse.generateResp(Status.SUCCESS, null,
           boardFacade.getBoardList(pageNo, pageSize, sortBy, direction).getContent());
+
     } catch (CustomException e) {
-      Status status = Status.valueOf(e.getClass().getSimpleName().replace("Exception", "").toUpperCase());
+      Status status = Status.valueOf(e.getClass()
+          .getSimpleName()
+          .replace("Exception", "")
+          .toUpperCase());
       return ApiResponse.generateResp(status, e.getMessage(), null);
+
     } catch (Exception e) {
-      return ApiResponse.generateResp(Status.ERROR, "게시판 목록 조회 중 오류가 발생하였습니다 : " + e.getMessage(), null);
+      return ApiResponse.generateResp(
+          Status.ERROR, "게시판 목록조회 중 오류가 발생하였습니다 : " + e.getMessage(), null);
     }
-
   }
-
-  /*
-  @Operation(summary = "게시판 목록 조회", description = "생성되어있는 모든 게시판을 조회합니다.")
-  @GetMapping("/list")
-  public ResponseEntity<List<GetBoardRespDto>> getBoardList(
-      @RequestParam(defaultValue = "0") int pageNo,
-      @RequestParam(defaultValue = "10") int pageSize,
-      @RequestParam(defaultValue = "createdAt") String sortBy,
-      @RequestParam(defaultValue = "DESC") String direction
-  ) {
-    return ResponseEntity.ok().body(boardFacade.getBoardList(pageNo, pageSize, sortBy, direction).getContent());
-  }
-  */
 
   @Operation(summary = "게시판 삭제", description = "선택한 게시판을 삭제합니다.")
   @PutMapping("/delete/{boardId}")
@@ -127,27 +110,19 @@ public class BoardController {
       boardFacade.deleteBoard(boardId);
 
       return ApiResponse.generateResp(Status.DELETE, "게시판이 삭제되었습니다.", null);
+
     } catch (CustomException e) {
-      Status status = Status.valueOf(e.getClass().getSimpleName().replace("Exception", "").toUpperCase());
+      Status status = Status.valueOf(e.getClass()
+          .getSimpleName()
+          .replace("Exception", "")
+          .toUpperCase());
       return ApiResponse.generateResp(status, e.getMessage(), null);
+
     } catch (Exception e) {
-      return ApiResponse.generateResp(Status.ERROR, "게시판 삭제 중 오류가 발생하였습니다 : " + e.getMessage(), null);
+      return ApiResponse.generateResp(
+          Status.ERROR, "게시판 삭제 중 오류가 발생하였습니다 : " + e.getMessage(), null);
     }
   }
-
-  /*
-  @Operation(summary = "게시판 삭제", description = "선택한 게시판을 삭제합니다.")
-  @PutMapping("/delete/{boardId}")
-  public ResponseEntity<String> deleteBoard(@PathVariable Long boardId) {
-    try {
-      boardFacade.deleteBoard(boardId);
-
-      return ResponseEntity.ok().body("게시판이 삭제되었습니다.");
-    } catch (Exception e) {
-      return ResponseEntity.badRequest().body("게시판 삭제 중 오류가 발생하였습니다 : " + e.getMessage());
-    }
-  }
-  */
 
   @Operation(summary = "게시판 수정", description = "선택한 게시판의 제목, 설명을 수정할 수 있습니다.")
   @PutMapping("/{boardId}")
@@ -156,26 +131,19 @@ public class BoardController {
     try {
       boardFacade.updateBoard(boardId, req);
 
-      return ApiResponse.generateResp(Status.UPDATE, "게시판 수정이 완료되었습니다.", null);
+      return ApiResponse.generateResp(
+          Status.UPDATE, "게시판 수정이 완료되었습니다.", null);
+
     } catch (CustomException e) {
-      Status status = Status.valueOf(e.getClass().getSimpleName().replace("Exception", "").toUpperCase());
+      Status status = Status.valueOf(e.getClass()
+          .getSimpleName()
+          .replace("Exception", "")
+          .toUpperCase());
       return ApiResponse.generateResp(status, e.getMessage(), null);
+
     } catch (Exception e) {
-      return ApiResponse.generateResp(Status.ERROR, "게시판 수정 중 오류가 발생하였습니다 : " + e.getMessage(), null);
+      return ApiResponse.generateResp(
+          Status.ERROR, "게시판 수정 중 오류가 발생하였습니다 : " + e.getMessage(), null);
     }
   }
-
-  /*
-  @Operation(summary = "게시판 수정", description = "선택한 게시판의 제목, 설명을 수정할 수 있습니다.")
-  @PutMapping("/{boardId}")
-  public ResponseEntity<String> updateBoard(@PathVariable Long boardId, @RequestBody UpdateBoardReqDto req) {
-    try {
-      boardFacade.updateBoard(boardId, req);
-
-      return ResponseEntity.ok().body("게시판 수정이 완료되었습니다.");
-    } catch (Exception e) {
-      return ResponseEntity.badRequest().body("게시판 수정 중 오류가 발생하였습니다 : " + e.getMessage());
-    }
-  }
-  */
 }

--- a/src/main/java/com/pawstime/pawstime/domain/board/entity/repository/BoardRepository.java
+++ b/src/main/java/com/pawstime/pawstime/domain/board/entity/repository/BoardRepository.java
@@ -11,7 +11,12 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface BoardRepository extends JpaRepository<Board, Long> {
 
-  @Query("SELECT b FROM Board b WHERE b.title = :title and b.isDelete = false")
+  @Query("SELECT b FROM Board b WHERE b.title = :title AND b.isDelete = false")
   Board findByTitleQuery(String title);
 
+  @Query("SELECT b FROM Board b WHERE b.boardId = :boardId AND b.isDelete = false")
+  Board findByIdQuery(Long boardId);
+
+  @Query("SELECT b FROM Board b WHERE b.isDelete = false")
+  Page<Board> findAllQuery(Pageable pageable);
 }

--- a/src/main/java/com/pawstime/pawstime/domain/board/facade/BoardFacade.java
+++ b/src/main/java/com/pawstime/pawstime/domain/board/facade/BoardFacade.java
@@ -53,9 +53,12 @@ public class BoardFacade {
   }
 
   @Transactional(readOnly = true)
-  public Page<GetBoardRespDto> getBoardList(int pageNo, int pageSize, String sortBy, String direction) {
+  public Page<GetBoardRespDto> getBoardList(
+      int pageNo, int pageSize, String sortBy, String direction
+  ) {
 
-    Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by(Sort.Direction.fromString(direction), sortBy));
+    Pageable pageable = PageRequest
+        .of(pageNo, pageSize, Sort.by(Sort.Direction.fromString(direction), sortBy));
 
     return readBoardService.getBoardList(pageable).map(GetBoardRespDto::from);
   }

--- a/src/main/java/com/pawstime/pawstime/domain/board/facade/BoardFacade.java
+++ b/src/main/java/com/pawstime/pawstime/domain/board/facade/BoardFacade.java
@@ -43,7 +43,7 @@ public class BoardFacade {
 
   @Transactional(readOnly = true)
   public GetBoardRespDto getBoard(Long boardId) {
-    Board board = readBoardService.findById(boardId);
+    Board board = readBoardService.findByIdQuery(boardId);
 
     if (board == null) {
       throw new NotFoundException("존재하지 않는 게시판 ID입니다.");
@@ -95,7 +95,7 @@ public class BoardFacade {
 
       // 이미 동일한 제목을 사용하는 게시판이 존재하는지 확인
       if (existingBoard != null && !existingBoard.getBoardId().equals(boardId)) {
-        throw new DuplicateException("이미 존재하는 게시판입니다.");
+        throw new DuplicateException("이미 존재하는 게시판 제목입니다.");
       }
 
       board.updateTitle(req.title());

--- a/src/main/java/com/pawstime/pawstime/domain/board/service/ReadBoardService.java
+++ b/src/main/java/com/pawstime/pawstime/domain/board/service/ReadBoardService.java
@@ -24,7 +24,11 @@ public class ReadBoardService {
     return boardRepository.findById(boardId).orElse(null);
   }
 
+  public Board findByIdQuery(Long boardId) {
+    return boardRepository.findByIdQuery(boardId);
+  }
+
   public Page<Board> getBoardList(Pageable pageable) {
-    return boardRepository.findAll(pageable);
+    return boardRepository.findAllQuery(pageable);
   }
 }

--- a/src/main/java/com/pawstime/pawstime/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/pawstime/pawstime/domain/comment/controller/CommentController.java
@@ -38,11 +38,17 @@ public class CommentController {
       commentFacade.createComment(postId, req);
 
       return ApiResponse.generateResp(Status.CREATE, "댓글 생성이 완료되었습니다.", null);
+
     } catch (CustomException e) {
-      Status status = Status.valueOf(e.getClass().getSimpleName().replace("Exception", "").toUpperCase());
+      Status status = Status.valueOf(e.getClass()
+          .getSimpleName()
+          .replace("Exception", "")
+          .toUpperCase());
       return ApiResponse.generateResp(status, e.getMessage(), null);
+
     } catch (Exception e) {
-      return ApiResponse.generateResp(Status.ERROR, "댓글 생성 중 오류가 발생하였습니다 : " + e.getMessage(), null);
+      return ApiResponse.generateResp(
+          Status.ERROR, "댓글 생성 중 오류가 발생하였습니다 : " + e.getMessage(), null);
     }
   }
 
@@ -55,12 +61,45 @@ public class CommentController {
       @RequestParam(defaultValue = "DESC") String direction
   ) {
     try {
-      return ApiResponse.generateResp(Status.SUCCESS, null, commentFacade.getCommentAll(pageNo, pageSize, sortBy, direction).getContent());
+      return ApiResponse.generateResp(Status.SUCCESS, null,
+          commentFacade.getCommentAll(pageNo, pageSize, sortBy, direction).getContent());
+
     } catch (CustomException e) {
-      Status status = Status.valueOf(e.getClass().getSimpleName().replace("Exception", "").toUpperCase());
+      Status status = Status.valueOf(e.getClass()
+          .getSimpleName()
+          .replace("Exception", "")
+          .toUpperCase());
       return ApiResponse.generateResp(status, e.getMessage(), null);
+
     } catch (Exception e) {
-      return ApiResponse.generateResp(Status.ERROR, "전체 댓글 조회 중 오류가 발생하였습니다 : " + e.getMessage(), null);
+      return ApiResponse.generateResp(
+          Status.ERROR, "전체 댓글 조회 중 오류가 발생하였습니다 : " + e.getMessage(), null);
+    }
+  }
+
+  @Operation(summary = "특정 게시글 댓글 조회", description = "선택한 게시글에 달린 댓글 목록을 조회합니다.")
+  @GetMapping("/list/{postId}")
+  public ResponseEntity<ApiResponse<List<GetCommentRespDto>>> getCommentByPost(
+      @PathVariable Long postId,
+      @RequestParam(defaultValue = "0") int pageNo,
+      @RequestParam(defaultValue = "10") int pageSize,
+      @RequestParam(defaultValue = "createdAt") String sortBy,
+      @RequestParam(defaultValue = "DESC") String direction
+  ) {
+    try {
+      return ApiResponse.generateResp(Status.SUCCESS, null,
+          commentFacade.getCommentByPost(postId, pageNo, pageSize, sortBy, direction).getContent());
+
+    } catch (CustomException e) {
+      Status status = Status.valueOf(e.getClass()
+          .getSimpleName()
+          .replace("Exception", "")
+          .toUpperCase());
+      return ApiResponse.generateResp(status, e.getMessage(), null);
+
+    } catch (Exception e) {
+      return ApiResponse.generateResp(
+          Status.ERROR, "게시글 댓글 조회 중 오류가 발생하였습니다 : " + e.getMessage(), null);
     }
   }
 }

--- a/src/main/java/com/pawstime/pawstime/domain/comment/entity/repository/CommentRepository.java
+++ b/src/main/java/com/pawstime/pawstime/domain/comment/entity/repository/CommentRepository.java
@@ -12,8 +12,11 @@ import org.springframework.stereotype.Repository;
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
   @Query("SELECT p FROM Post p WHERE p.postId = :postId AND p.isDelete = false")
-  Post findByIdQuery(Long postId);
+  Post findPostByIdQuery(Long postId);
 
   @Query("SELECT c FROM Comment c WHERE c.isDelete = false")
   Page<Comment> findAllQuery(Pageable pageable);
+
+  @Query("SELECT c FROM Comment c WHERE c.post.id = :postId AND c.isDelete = false")
+  Page<Comment> findAllByPostQuery(Long postId, Pageable pageable);
 }

--- a/src/main/java/com/pawstime/pawstime/domain/comment/facade/CommentFacade.java
+++ b/src/main/java/com/pawstime/pawstime/domain/comment/facade/CommentFacade.java
@@ -7,6 +7,7 @@ import com.pawstime.pawstime.domain.comment.service.ReadCommentService;
 import com.pawstime.pawstime.domain.post.entity.Post;
 import com.pawstime.pawstime.global.exception.InvalidException;
 import com.pawstime.pawstime.global.exception.NotFoundException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -26,7 +27,7 @@ public class CommentFacade {
   private final CreateCommentService createCommentService;
 
   public void createComment(Long postId, CreateCommentReqDto req) {
-    Post post = readCommentService.findByIdQuery(postId);
+    Post post = readCommentService.getPostById(postId);
 
     if (post == null) {
       throw new NotFoundException("존재하지 않는 게시글 ID입니다.");
@@ -41,8 +42,28 @@ public class CommentFacade {
   }
 
   @Transactional(readOnly = true)
-  public Page<GetCommentRespDto> getCommentAll(int pageNo, int pageSize, String sortBy, String direction) {
-    Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by(Sort.Direction.fromString(direction), sortBy));
+  public Page<GetCommentRespDto> getCommentAll(
+      int pageNo, int pageSize, String sortBy, String direction
+  ) {
+    Pageable pageable = PageRequest
+        .of(pageNo, pageSize, Sort.by(Sort.Direction.fromString(direction), sortBy));
+
     return readCommentService.getCommentAll(pageable).map(GetCommentRespDto::from);
+  }
+
+  @Transactional(readOnly = true)
+  public Page<GetCommentRespDto> getCommentByPost(
+      Long postId, int pageNo, int pageSize, String sortBy, String direction
+  ) {
+    Post post = readCommentService.getPostById(postId);
+
+    if (post == null) {
+      throw new NotFoundException("존재하지 않는 게시글 ID입니다.");
+    }
+
+    Pageable pageable = PageRequest
+        .of(pageNo, pageSize, Sort.by(Sort.Direction.fromString(direction), sortBy));
+
+    return readCommentService.getCommentByPost(postId, pageable).map(GetCommentRespDto::from);
   }
 }

--- a/src/main/java/com/pawstime/pawstime/domain/comment/service/ReadCommentService.java
+++ b/src/main/java/com/pawstime/pawstime/domain/comment/service/ReadCommentService.java
@@ -15,11 +15,15 @@ public class ReadCommentService {
 
   private final CommentRepository commentRepository;
 
-  public Post findByIdQuery(Long postId) {
-    return commentRepository.findByIdQuery(postId);
+  public Post getPostById(Long postId) {
+    return commentRepository.findPostByIdQuery(postId);
   }
 
   public Page<Comment> getCommentAll(Pageable pageable) {
     return commentRepository.findAllQuery(pageable);
+  }
+
+  public Page<Comment> getCommentByPost(Long postId, Pageable pageable) {
+    return commentRepository.findAllByPostQuery(postId, pageable);
   }
 }

--- a/src/main/java/com/pawstime/pawstime/global/common/ApiResponse.java
+++ b/src/main/java/com/pawstime/pawstime/global/common/ApiResponse.java
@@ -17,7 +17,9 @@ public class ApiResponse<T> {
     this.data = data;
   }
 
-  public static <T> ResponseEntity<ApiResponse<T>> generateResp(Status status, String message, T data) {
+  public static <T> ResponseEntity<ApiResponse<T>> generateResp(
+      Status status, String message, T data
+  ) {
     ApiResponse<T> apiResponse =  new ApiResponse<>(status, message, data);
     return ResponseEntity.status(status.getHttpStatus()).body(apiResponse);
   }

--- a/src/main/java/com/pawstime/pawstime/global/enums/Status.java
+++ b/src/main/java/com/pawstime/pawstime/global/enums/Status.java
@@ -10,7 +10,7 @@ public enum Status {
   SUCCESS("Success", "요청이 성공적으로 처리된 경우", HttpStatus.OK),
   CREATE("Create", "리소스가 성공적으로 생성된 경우", HttpStatus.CREATED),
   UPDATE("Update", "리소스가 성공적으로 수정된 경우", HttpStatus.OK),
-  DELETE("Delete", "리소스가 성공적으로 삭제된 경우", HttpStatus.NO_CONTENT),
+  DELETE("Delete", "리소스가 성공적으로 삭제된 경우", HttpStatus.OK),
 
   // 실패 상태
   INVALID("Invalid", "요청 데이터가 잘못된 경우", HttpStatus.BAD_REQUEST),


### PR DESCRIPTION
## 📝 설명 (Description)
게시판 조회에서 삭제된 게시판을 제외하도록 쿼리를 수정하였습니다.

--- 

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:
- [x] 변경사항 1 : 기존의 게시판 조회 쿼리에서 @Query를 사용하여 isDelete가 false인 게시판만 조회되도록 필터링 로직을 추가하였습니다. 이제 삭제된 게시판은 조회되지 않습니다.

---

## 📌 참고 사항 (Additional Notes)
해당 변경 사항은 삭제된 게시판을 제외한 조회를 목적으로 하며, 기존 데이터에서 isDelete 값이 true인 게시판이 있다면 
이들은 더 이상 조회되지 않으니 확인 부탁드립니다.
