### PR TITLE
feat: 댓글 삭제 기능 구현

### DIFF
--- a/src/main/java/com/pawstime/pawstime/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/pawstime/pawstime/domain/comment/controller/CommentController.java
@@ -16,6 +16,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -100,6 +101,28 @@ public class CommentController {
     } catch (Exception e) {
       return ApiResponse.generateResp(
           Status.ERROR, "게시글 댓글 조회 중 오류가 발생하였습니다 : " + e.getMessage(), null);
+    }
+  }
+
+  @Operation(summary = "댓글 삭제", description = "선택한 댓글을 삭제합니다.")
+  @PutMapping("/{commentId}")
+  public ResponseEntity<ApiResponse<Void>> deleteComment(@PathVariable Long commentId) {
+    try {
+
+      commentFacade.deleteComment(commentId);
+
+      return ApiResponse.generateResp(Status.DELETE, "댓글이 삭제되었습니다.", null);
+
+    } catch (CustomException e) {
+      Status status = Status.valueOf(e.getClass()
+          .getSimpleName()
+          .replace("Exception", "")
+          .toUpperCase());
+      return ApiResponse.generateResp(status, e.getMessage(), null);
+
+    } catch (Exception e) {
+      return ApiResponse.generateResp(
+          Status.ERROR, "댓글 삭제 중 오류가 발생하였습니다 : " + e.getMessage(), null);
     }
   }
 }

--- a/src/main/java/com/pawstime/pawstime/domain/comment/facade/CommentFacade.java
+++ b/src/main/java/com/pawstime/pawstime/domain/comment/facade/CommentFacade.java
@@ -2,6 +2,7 @@ package com.pawstime.pawstime.domain.comment.facade;
 
 import com.pawstime.pawstime.domain.comment.dto.req.CreateCommentReqDto;
 import com.pawstime.pawstime.domain.comment.dto.resp.GetCommentRespDto;
+import com.pawstime.pawstime.domain.comment.entity.Comment;
 import com.pawstime.pawstime.domain.comment.service.CreateCommentService;
 import com.pawstime.pawstime.domain.comment.service.ReadCommentService;
 import com.pawstime.pawstime.domain.post.entity.Post;
@@ -65,5 +66,20 @@ public class CommentFacade {
         .of(pageNo, pageSize, Sort.by(Sort.Direction.fromString(direction), sortBy));
 
     return readCommentService.getCommentByPost(postId, pageable).map(GetCommentRespDto::from);
+  }
+
+  public void deleteComment(Long commentId) {
+    Comment comment = readCommentService.findById(commentId);
+
+    if (comment == null) {
+      throw new NotFoundException("존재하지 않는 댓글 ID입니다.");
+    }
+
+    if (comment.isDelete()) {
+      throw new NotFoundException("이미 삭제된 댓글입니다.");
+    }
+
+    comment.softDelete();
+    createCommentService.createComment(comment);
   }
 }

--- a/src/main/java/com/pawstime/pawstime/domain/comment/service/ReadCommentService.java
+++ b/src/main/java/com/pawstime/pawstime/domain/comment/service/ReadCommentService.java
@@ -26,4 +26,8 @@ public class ReadCommentService {
   public Page<Comment> getCommentByPost(Long postId, Pageable pageable) {
     return commentRepository.findAllByPostQuery(postId, pageable);
   }
+
+  public Comment findById(Long commentId) {
+    return commentRepository.findById(commentId).orElse(null);
+  }
 }


### PR DESCRIPTION
## 📝 설명 (Description)
댓글 삭제 기능을 구현하였습니다.
사용자가 댓글 삭제 요청을 보낼 경우, 해당 댓글의 isDelete 필드를 true로 변경하여 논리적으로 삭제되도록 처리했습니다.

--- 

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:
- [x] 변경사항 1 : 삭제 요청이 들어오면 해당 댓글의 isDelete 필드를 true로 업데이트하도록 구현하였습니다. (isDelete 필드가 true인 댓글을 조회 결과에서 제외됩니다.)

---

## 📌 참고 사항 (Additional Notes)
삭제된 댓글은 실제 데이터베이스에서 제거되지 않고, 논리적 삭제 방식으로 처리됩니다.

