### PR TITLE
좋아요:기능 추가

### DIFF
--- a/src/main/java/com/pawstime/pawstime/domain/like/entity/Like.java
+++ b/src/main/java/com/pawstime/pawstime/domain/like/entity/Like.java
@@ -1,4 +1,31 @@
 package com.pawstime.pawstime.domain.like.entity;
 
+import com.pawstime.pawstime.domain.post.entity.Post;
+import com.pawstime.pawstime.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "likes")
+
 public class Like {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "like_id")
+    private Long likeId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
 }

--- a/src/main/java/com/pawstime/pawstime/domain/like/entity/repository/LikeRepository.java
+++ b/src/main/java/com/pawstime/pawstime/domain/like/entity/repository/LikeRepository.java
@@ -1,7 +1,17 @@
 package com.pawstime.pawstime.domain.like.entity.repository;
 
 
+import com.pawstime.pawstime.domain.like.entity.Like;
+import com.pawstime.pawstime.domain.post.entity.Post;
+import com.pawstime.pawstime.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface LikeRepository  {
+import java.util.Optional;
+
+public interface LikeRepository extends JpaRepository<Like, Long> {
+    // 특정 게시글과 사용자의 좋아요 관계를 찾는 쿼리
+    Optional<Like> findByPost(Post post);
+
+    // 특정 게시글에 대한 좋아요 수를 가져오는 쿼리
+    long countByPost(Post post);
 }

--- a/src/main/java/com/pawstime/pawstime/domain/like/facade/LikeFacade.java
+++ b/src/main/java/com/pawstime/pawstime/domain/like/facade/LikeFacade.java
@@ -1,0 +1,21 @@
+package com.pawstime.pawstime.domain.like.facade;
+
+import com.pawstime.pawstime.domain.like.service.LikeService;
+import com.pawstime.pawstime.domain.post.entity.Post;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Slf4j
+@Transactional
+@Component
+@RequiredArgsConstructor
+public class LikeFacade {
+    private final LikeService likeService;
+
+    public void toggleLike(Post post) {
+        likeService.toggleLike(post);
+    }
+}

--- a/src/main/java/com/pawstime/pawstime/domain/like/service/LikeService.java
+++ b/src/main/java/com/pawstime/pawstime/domain/like/service/LikeService.java
@@ -1,0 +1,46 @@
+package com.pawstime.pawstime.domain.like.service;
+
+import com.pawstime.pawstime.domain.like.entity.Like;
+import com.pawstime.pawstime.domain.like.entity.repository.LikeRepository;
+import com.pawstime.pawstime.domain.post.entity.Post;
+import com.pawstime.pawstime.domain.post.entity.repository.PostRepository;
+import com.pawstime.pawstime.domain.user.entity.User;
+import com.pawstime.pawstime.global.exception.NotFoundException;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.annotations.NotFound;
+import org.springframework.stereotype.Service;
+
+import java.io.NotActiveException;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+
+public class LikeService {
+    private final LikeRepository likeRepository;
+    private final PostRepository postRepository;
+
+    public void toggleLike(Post post) {
+        if (post.isDelete()) {
+            throw new NotFoundException("삭제된 게시글에는 좋아요를 누를 수 없습니다.");
+        }
+
+        Optional<Like> existingLike = likeRepository.findByPost(post);
+
+        if (existingLike.isPresent()) {
+            likeRepository.delete(existingLike.get());
+            post.removeLike(existingLike.get());
+            post.decrementLikesCount();
+        } else {
+            Like newLike = Like.builder()
+                    .post(post)
+                    .build();
+            likeRepository.save(newLike);
+            post.addLike(newLike);
+            post.incrementLikesCount();
+        }
+
+        postRepository.save(post);  // 변경된 post 저장
+    }
+}

--- a/src/main/java/com/pawstime/pawstime/domain/post/controller/PostController.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/controller/PostController.java
@@ -1,12 +1,16 @@
 package com.pawstime.pawstime.domain.post.controller;
 
 import com.pawstime.pawstime.domain.board.service.ReadBoardService;
+import com.pawstime.pawstime.domain.like.facade.LikeFacade;
 import com.pawstime.pawstime.domain.post.dto.req.CreatePostReqDto;
 import com.pawstime.pawstime.domain.post.dto.req.UpdatePostReqDto;
 import com.pawstime.pawstime.domain.post.dto.resp.GetDetailPostRespDto;
 import com.pawstime.pawstime.domain.post.dto.resp.GetListPostRespDto;
+
+import com.pawstime.pawstime.domain.post.entity.Post;
 import com.pawstime.pawstime.domain.post.facade.PostFacade;
 import com.pawstime.pawstime.domain.post.service.GetListPostService;
+import com.pawstime.pawstime.domain.user.entity.User;
 import com.pawstime.pawstime.global.common.ApiResponse;
 import com.pawstime.pawstime.global.enums.Status;
 import com.pawstime.pawstime.global.exception.CustomException;
@@ -37,8 +41,7 @@ import java.util.stream.Collectors;
 public class PostController {
 
     private final PostFacade postFacade;
-    private final GetListPostService getListPostService;
-    private final ReadBoardService readBoardService;
+    private final LikeFacade likeFacade;
 
     @Operation(summary = "게시글 생성", description = "게시글을 생성 할 수 있습니다.")
     @PostMapping()
@@ -138,5 +141,18 @@ public class PostController {
 
         // Pageable 객체 생성
         return PageRequest.of(page, size, sortBy);
+    }
+
+    @PostMapping("/{postId}/like")
+    @Operation(summary = "좋아요", description = "게시글에 좋아요를 누를 수 있습니다.")
+
+    public ResponseEntity<ApiResponse<Integer>> toggleLike(@PathVariable Long postId) {
+        try {
+            Post post = postFacade.getPostId(postId);  // 게시글 가져오기
+            likeFacade.toggleLike(post);  // 좋아요 토글 처리
+            return ApiResponse.generateResp(Status.SUCCESS, null, post.getLikesCount());  // 좋아요 수 반환
+        } catch (NotFoundException e) {
+            return ApiResponse.generateResp(Status.NOTFOUND, e.getMessage(), null);
+        }
     }
 }

--- a/src/main/java/com/pawstime/pawstime/domain/post/dto/req/CreatePostReqDto.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/dto/req/CreatePostReqDto.java
@@ -30,7 +30,6 @@ public record CreatePostReqDto(
                 .content(this.content)
                 .board(board)
                 .category(this.category)
-                .likesCount(0)
                 .build();
     }
 }

--- a/src/main/java/com/pawstime/pawstime/domain/post/entity/Post.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/entity/Post.java
@@ -1,12 +1,16 @@
 package com.pawstime.pawstime.domain.post.entity;
 
 import com.pawstime.pawstime.domain.board.entity.Board;
+import com.pawstime.pawstime.domain.like.entity.Like;
 import com.pawstime.pawstime.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Builder
@@ -35,8 +39,12 @@ public class Post extends BaseEntity {
   @JoinColumn(name = "board_id", nullable = false)
   private Board board; // Board 엔티티와 관계 설정
 
+  // 좋아요 관계 추가 (Post와 Like의 1:N 관계 설정)
+  @OneToMany(mappedBy = "post", fetch = FetchType.LAZY )
+  private List<Like> likes = new ArrayList<>();  // 빈 리스트로 초기화
+
   @Column(name = "likes_count", nullable = false)
-  private int likesCount = 0; // 기본값을 0으로 설정
+  private int likesCount = 0;
 
   @Column(name = "views", nullable = false)
   private int views = 0; // 조회수 기본값을 0으로 설정
@@ -50,14 +58,12 @@ public class Post extends BaseEntity {
     TECH, LIFESTYLE, EDUCATION, ENTERTAINMENT
   }
 
-  public void setTitle(String title){
+  public void setTitle(String title) {
     this.title = title;
   }
-  public void setContent(String content){
+
+  public void setContent(String content) {
     this.content = content;
-  }
-  public void setCategory(PostCategory category){
-    this.category = category;
   }
 
   // 조회수를 증가시키는 메서드
@@ -65,4 +71,28 @@ public class Post extends BaseEntity {
     this.views += 1;
   }
 
+  // 좋아요 수 계산 (Like 엔티티와의 관계에서 개수를 계산)
+  @Transient
+  public int getLikesCount() {
+    return likes.size();  // 연관된 Like 객체 수로 좋아요 수 계산
+  }
+
+  // 좋아요를 추가하는 메서드
+  public void addLike(Like like) {
+    this.likes.add(like);
+  }
+
+  // 좋아요를 삭제하는 메서드
+  public void removeLike(Like like) {
+    this.likes.remove(like);
+  }
+
+
+  public void incrementLikesCount() {
+    this.likesCount++;
+  }
+
+  public void decrementLikesCount() {
+    this.likesCount--;
+  }
 }

--- a/src/main/java/com/pawstime/pawstime/domain/post/facade/PostFacade.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/facade/PostFacade.java
@@ -3,6 +3,7 @@ package com.pawstime.pawstime.domain.post.facade;
 import com.pawstime.pawstime.domain.board.entity.Board;
 import com.pawstime.pawstime.domain.board.entity.repository.BoardRepository;
 import com.pawstime.pawstime.domain.board.service.ReadBoardService;
+import com.pawstime.pawstime.domain.like.service.LikeService;
 import com.pawstime.pawstime.domain.post.dto.req.CreatePostReqDto;
 import com.pawstime.pawstime.domain.post.dto.req.UpdatePostReqDto;
 import com.pawstime.pawstime.domain.post.dto.resp.GetDetailPostRespDto;
@@ -10,6 +11,7 @@ import com.pawstime.pawstime.domain.post.dto.resp.GetListPostRespDto;
 import com.pawstime.pawstime.domain.post.entity.Post;
 import com.pawstime.pawstime.domain.post.entity.repository.PostRepository;
 import com.pawstime.pawstime.domain.post.service.*;
+import com.pawstime.pawstime.domain.user.entity.User;
 import com.pawstime.pawstime.global.exception.DuplicateException;
 import com.pawstime.pawstime.global.exception.InvalidException;
 import com.pawstime.pawstime.global.exception.NotFoundException;
@@ -35,8 +37,7 @@ public class PostFacade {
     private final UpdatePostService updatePostService;
     private final GetDetailPostService getDetailPostService;
     private final GetListPostService getListPostService;
-
-
+    private final PostRepository postRepository;
 
     public void createPost(CreatePostReqDto req) {
         if (req.boardId() == null || req.boardId().toString().isEmpty()) {
@@ -117,6 +118,7 @@ public class PostFacade {
     public Page<GetListPostRespDto> getPostList(Long boardId, String keyword, Pageable pageable) {
         return getListPostService.getPostList(boardId, keyword, pageable);
     }
-
-
+    public Post getPostId(Long postId) {
+        return postRepository.findById(postId).orElseThrow(() -> new NotFoundException("게시글을 찾을 수 없습니다."));
+    }
 }

--- a/src/main/java/com/pawstime/pawstime/domain/post/service/PostSpecification.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/service/PostSpecification.java
@@ -9,8 +9,6 @@ import org.springframework.data.jpa.domain.Specification;
 
 public class PostSpecification {
 
-
-
     public static Specification<Post> isNotDeleted() {
         return (root, query, criteriaBuilder) -> criteriaBuilder.isFalse(root.get("isDelete"));
     }


### PR DESCRIPTION
## 📝 설명 (Description)

이번 PR에서는 Like 기능에서 user엔티티 없이 특정 게시글에 대해 좋아요를 토글할 수 있도록 수정하였습니다. 사용자가 Swagger에서 postId만 입력해도 likes_count가 증가하거나 감소하도록 구현하였습니다.
--- 

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:
- [ ] toggleLike 메서드 수정:
특정 게시글에 대해 좋아요 추가 또는 취소 기능 구현.
게시글이 삭제되었는지 확인 후 예외 처리 추가.
post.incrementLikesCount()와 post.decrementLikesCount()를 사용해 좋아요 수 관리.
변경된 게시글 상태를 저장하도록 PostRepository 호출 추가.

- [ ] Swagger API 연동 확인:
Swagger에서 postId만 입력하여 좋아요 수를 수정 가능하도록 API 연동 테스트 완료.

- [ ] 좋아요 수 즉시 반영:
Post 엔티티의 likes_count 필드를 사용하여 좋아요 수를 즉시 업데이트하도록 구현.

---

## 📌 참고 사항 (Additional Notes)

Post 엔티티 변경:

incrementLikesCount()와 decrementLikesCount() 메서드를 추가하여 likes_count 필드 값을 효율적으로 관리하도록 수정.
LikeService 로직 개선:

toggleLike 메서드에서 Like 엔티티 리스트를 관리하지 않고, 단순히 likes_count 필드 값으로 좋아요 수를 반영.
데이터베이스 반영 확인:

Swagger에서 execute를 눌러 likes_count가 변경되는지 테스트 완료.
DBeaver에서 데이터 확인 완료.
추가 의존성/환경 설정:

의존성이나 추가 설정 변경은 없으나, 향후 User 엔티티를 연동할 경우 로직을 재구성해야 할 수 있습니다.
