### PR TITLE
feat:게시글 이미지 엔티티 생성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,8 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	//implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'software.amazon.awssdk:s3:2.20.0'
+
 }
 
 //tasks.named('test') {

--- a/src/main/java/com/pawstime/pawstime/domain/image/entity/Image.java
+++ b/src/main/java/com/pawstime/pawstime/domain/image/entity/Image.java
@@ -1,0 +1,34 @@
+package com.pawstime.pawstime.domain.image.entity;
+
+import com.pawstime.pawstime.domain.post.entity.Post;
+import com.pawstime.pawstime.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "Image")
+public class Image extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "image_id")
+    private Long imageId;
+
+    @Column(nullable = false)
+    private String url; //s3에 저장된 이미지 url
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="post_id")
+    private Post post;
+
+    public void setPost(Post post){
+        this.post = post;
+    }
+}

--- a/src/main/java/com/pawstime/pawstime/domain/post/entity/Post.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/entity/Post.java
@@ -1,6 +1,7 @@
 package com.pawstime.pawstime.domain.post.entity;
 
 import com.pawstime.pawstime.domain.board.entity.Board;
+import com.pawstime.pawstime.domain.image.entity.Image;
 import com.pawstime.pawstime.domain.like.entity.Like;
 import com.pawstime.pawstime.global.entity.BaseEntity;
 import jakarta.persistence.*;
@@ -49,6 +50,10 @@ public class Post extends BaseEntity {
   @Column(name = "views", nullable = false)
   private int views = 0; // 조회수 기본값을 0으로 설정
 
+  //게시글 생성/삭제 시 연관된 이미지도 함께 처리.
+  @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<Image> images = new ArrayList<>(); // 게시글과 연관된 이미지 리스트
+
 
   public void setTitle(String title) {
     this.title = title;
@@ -79,12 +84,23 @@ public class Post extends BaseEntity {
     this.likes.remove(like);
   }
 
-
   public void incrementLikesCount() {
     this.likesCount++;
   }
 
   public void decrementLikesCount() {
     this.likesCount--;
+  }
+
+  // 연관된 이미지 추가
+  public void addImage(Image image) {
+    images.add(image);
+    image.setPost(this);
+  }
+
+  // 연관된 이미지 제거
+  public void removeImage(Image image) {
+    images.remove(image);
+    image.setPost(null);
   }
 }


### PR DESCRIPTION
## 📝 설명 (Description)

이번 변경은 게시글(Post)과 이미지(Image) 엔티티 간의 관계 설정 및 관련 메서드를 추가하는 작업입니다. Post 엔티티에서 여러 이미지를 관리할 수 있도록 OneToMany 관계를 설정하고, Image 엔티티에서는 ManyToOne 관계로 Post와 연관을 맺습니다. 또한, Image 엔티티에서 이미지를 추가하거나 제거할 때 setPost() 메서드를 사용하여 Post와 Image 객체 간의 연관 관계를 동적으로 설정합니다.

--- 

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:
- [x] Post 엔티티에 OneToMany 관계를 설정하여 여러 이미지(Image)를 관리할 수 있도록 변경
- [x] Image 엔티티에 ManyToOne 관계를 설정하여 게시글(Post)과 연결되도록 함
- [x] Image 엔티티에 setPost() 메서드를 추가하여 이미지와 게시글 간의 연관 관계 설정
- [x] Post 엔티티에 addImage() 메서드를 추가하여 이미지를 추가할 때 자동으로 setPost()를 호출하도록 설정

---

## 📌 참고 사항 (Additional Notes)
Post와 Image 엔티티 간의 연관 관계는 CascadeType.ALL을 사용하여 게시글 삭제 시 해당 게시글과 연관된 이미지도 함께 삭제됩니다. (OrphanRemoval 설정)
이미지를 추가하거나 제거할 때 Post 엔티티의 addImage() 및 removeImage() 메서드를 통해 관계를 관리합니다.
Image 엔티티에서 @ManyToOne 관계에 fetch = FetchType.LAZY를 설정하여 지연 로딩 방식으로 Post 엔티티를 로딩합니다.
Post 엔티티에 addImage() 메서드를 사용하면 Image 엔티티의 setPost()가 자동으로 호출되므로, 명시적으로 setPost()를 호출할 필요가 없습니다.
