### PR TITLE
feat/ImageUploadmethod

### DIFF
--- a/src/main/java/com/pawstime/pawstime/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/pawstime/pawstime/domain/comment/controller/CommentController.java
@@ -14,14 +14,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @Tag(name = "Comment", description = "댓글 API")
@@ -106,7 +99,7 @@ public class CommentController {
   }
 
   @Operation(summary = "댓글 삭제", description = "선택한 댓글을 삭제합니다.")
-  @PutMapping("/{commentId}")
+  @DeleteMapping("/{commentId}")
   public ResponseEntity<ApiResponse<Void>> deleteComment(@PathVariable Long commentId) {
     try {
 

--- a/src/main/java/com/pawstime/pawstime/domain/image/entity/Image.java
+++ b/src/main/java/com/pawstime/pawstime/domain/image/entity/Image.java
@@ -25,7 +25,7 @@ public class Image extends BaseEntity {
     private String imageUrl; //s3에 저장된 이미지 url
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="post_id")
+    @JoinColumn(name = "post_id", nullable = false)
     private Post post;
 
     public void setPost(Post post){

--- a/src/main/java/com/pawstime/pawstime/domain/post/service/S3Service.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/service/S3Service.java
@@ -1,5 +1,6 @@
 package com.pawstime.pawstime.domain.post.service;
 
+import com.amazonaws.AmazonServiceException;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.s3.AmazonS3;
@@ -7,7 +8,6 @@ import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
-import org.apache.tomcat.util.http.fileupload.impl.FileSizeLimitExceededException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -23,8 +23,6 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class S3Service {
 
-    private static final long MAX_FILE_SIZE = 10 * 1024 * 1024;  // 10MB 제한
-
     @Value("${aws.s3.access-key-id}")
     private String accessKeyId;
 
@@ -37,22 +35,30 @@ public class S3Service {
     @Value("${aws.s3.bucket-name}")
     private String bucketName;
 
+    @Value("${aws.s3.max-file-size}")
+    private long maxFileSize; // application.yml에서 파일 크기 제한 값을 읽어옵니다.
+
     private AmazonS3 amazonS3;
 
     @PostConstruct
     public void init() {
+
+        System.out.println("Access Key: " + accessKeyId); // 값이 제대로 주입되었는지 확인
+        System.out.println("Region: " + region);  // 값이 제대로 주입되었는지 확인
         BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKeyId, secretAccessKey);
         this.amazonS3 = AmazonS3ClientBuilder.standard()
                 .withRegion(region)
                 .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
                 .build();
     }
-
     public List<String> uploadImages(List<MultipartFile> files) {
         List<String> imageUrls = new ArrayList<>();
+
         for (MultipartFile file : files) {
-            if (file.getSize() > MAX_FILE_SIZE) {
-                throw new FileSizeLimitExceededException("파일 크기가 너무 큽니다. 최대 크기는 10MB입니다.");
+            long actualSize = file.getSize();
+
+            if (actualSize > maxFileSize) {
+                throw new RuntimeException("파일 크기가 너무 큽니다. 최대 크기는 " + maxFileSize / 1024 / 1024 + "MB입니다.");
             }
             String uniqueFileName = UUID.randomUUID().toString() + "_" + file.getOriginalFilename();
             File tempFile = convertMultipartFileToFile(file);
@@ -64,18 +70,23 @@ public class S3Service {
         }
         return imageUrls;
     }
-
     private String uploadFile(File file, String key) {
-        amazonS3.putObject(new PutObjectRequest(bucketName, key, file));
-        return amazonS3.getUrl(bucketName, key).toString();
+        try {
+            amazonS3.putObject(new PutObjectRequest(bucketName, key, file));
+            return amazonS3.getUrl(bucketName, key).toString();
+        } catch (AmazonServiceException e) {
+            throw new RuntimeException("업로드 실패: " + e.getErrorMessage(), e);
+        }
     }
-
     private File convertMultipartFileToFile(MultipartFile file) {
         File convertedFile = new File(file.getOriginalFilename());
         try (FileOutputStream fos = new FileOutputStream(convertedFile)) {
             fos.write(file.getBytes());
         } catch (IOException e) {
             throw new RuntimeException("파일 변환 오류: " + e.getMessage(), e);
+        }
+        if (!convertedFile.exists()) {
+            throw new RuntimeException("임시 파일 생성에 실패했습니다.");
         }
         return convertedFile;
     }

--- a/src/main/java/com/pawstime/pawstime/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/pawstime/pawstime/global/config/security/SecurityConfig.java
@@ -8,9 +8,13 @@ import com.pawstime.pawstime.global.security.user.service.CustomUserDetailsServi
 import lombok.AllArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.SecurityBuilder;
+import org.springframework.security.config.annotation.web.WebSecurityConfigurer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfiguration;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.servlet.configuration.WebMvcSecurityConfiguration;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -18,7 +22,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
-@EnableWebSecurity
+//@EnableWebSecurity
 @AllArgsConstructor
 public class SecurityConfig {
 
@@ -36,6 +40,8 @@ public class SecurityConfig {
   public PasswordEncoder passwordEncoder() {
     return new BCryptPasswordEncoder();
   }
+
+
 
   @Bean
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {

--- a/src/main/java/com/pawstime/pawstime/global/enums/ResponseCode.java
+++ b/src/main/java/com/pawstime/pawstime/global/enums/ResponseCode.java
@@ -5,6 +5,7 @@ public enum ResponseCode {
   SIGNUP_SUCCESS("회원가입 성공"),
   GENERAL_ERROR("에러 발생");
 
+
   private final String message;
 
   ResponseCode(String message) {

--- a/src/main/java/com/pawstime/pawstime/global/handler/CustomExceptionHandler.java
+++ b/src/main/java/com/pawstime/pawstime/global/handler/CustomExceptionHandler.java
@@ -2,6 +2,7 @@ package com.pawstime.pawstime.global.handler;
 
 import com.pawstime.pawstime.global.enums.ResponseCode;
 import com.pawstime.pawstime.web.api.user.dto.resp.Response;
+import org.apache.tomcat.util.http.fileupload.impl.FileSizeLimitExceededException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -9,8 +10,11 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.WebRequest;
 
+
+
 @ControllerAdvice
 public class CustomExceptionHandler {
+
 
   @ExceptionHandler(Exception.class)
   public final ResponseEntity<Response<String>> handleAllExceptions(Exception e, WebRequest request) {

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -24,5 +24,7 @@ spring:
 server:
   port: 8080
 
+
+
 #mybatis:
 #  mapper-locations: classpath:mapper/*.xml


### PR DESCRIPTION
## 📝 설명 (Description)
간단하게 무엇을 변경했는지 설명해주세요. <br>

AWS S3와 연동하여 멀티파일 업로드 기능을 구현했습니다. 이 기능을 통해 사용자는 여러 파일을 한 번에 업로드할 수 있으며, 업로드된 파일은 지정된 S3 버킷에 저장됩니다.


--- 

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:
- [ ]S3Service 구현: AWS S3 SDK를 사용하여 파일을 업로드하고 URL을 반환하는 기능 추가.
- [ ] 멀티파일 업로드 메서드 구현: 여러 파일을 처리하여 S3에 업로드하고, 결과 URL 리스트를 반환하는 메서드 추가.
- [ ]  컨트롤러 추가: 멀티파일 업로드 요청을 처리하고 결과를 반환하는 API 추가.
- [ ] application.yml 수정: S3 설정 정보 (액세스 키, 시크릿 키, 리전, 버킷 이름) 추가.

---

## 📌 참고 사항 (Additional Notes)
application.yml에 민감한 정보 제거 필요
AWS S3 관련 설정(access-key-id, secret-access-key 등)은 절대 코드베이스에 포함시키지 않아야 합니다.
깃허브에 올릴 때는 해당 정보를 제거하고, 로컬 또는 배포 환경에서만 추가해야 합니다.
환경 설정 추가
application.yml 파일 예제:
yaml
aws:
  s3:
    access-key-id: <YOUR_ACCESS_KEY_ID>
    secret-access-key: <YOUR_SECRET_ACCESS_KEY>
    region: ap-northeast-2
    bucket-name: paws-time-bucket
    max-file-size: 100
이 정보는 환경 변수로 관리하거나, .gitignore로 설정된 별도의 파일에서 관리하는 것이 권장됩니다.
파일 크기 제한
업로드 가능한 파일 크기는 max-file-size로 설정되어 있으며, 필요 시 설정을 변경해야 합니다.
의존성 추가
AWS S3 SDK를 사용하기 위해 의존성을 추가했습니다.
gradle
코드 복사
implementation 'software.amazon.awssdk:s3'
주의사항
업로드 실패 시 예외 처리가 추가로 필요할 수 있습니다.
대용량 파일 업로드 시 타임아웃 문제를 예방하기 위해 비동기 업로드 또는 청크 업로드를 고려해야 합니다.
