### PR TITLE
Feat/create fommater#75

### DIFF
--- a/src/main/java/com/pawstime/pawstime/domain/board/service/CreateBoardService.java
+++ b/src/main/java/com/pawstime/pawstime/domain/board/service/CreateBoardService.java
@@ -14,6 +14,7 @@ public class CreateBoardService {
 
   public void createBoard(Board board, BoardType boardType) {
     board.setBoardType(boardType);
+
     boardRepository.save(board);
   }
 }

--- a/src/main/java/com/pawstime/pawstime/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/pawstime/pawstime/domain/comment/controller/CommentController.java
@@ -2,7 +2,9 @@ package com.pawstime.pawstime.domain.comment.controller;
 
 import com.pawstime.pawstime.domain.comment.dto.req.CreateCommentReqDto;
 import com.pawstime.pawstime.domain.comment.dto.req.UpdateCommentReqDto;
+import com.pawstime.pawstime.domain.comment.dto.resp.CreateCommentRespDto;
 import com.pawstime.pawstime.domain.comment.dto.resp.GetCommentRespDto;
+import com.pawstime.pawstime.domain.comment.entity.Comment;
 import com.pawstime.pawstime.domain.comment.facade.CommentFacade;
 import com.pawstime.pawstime.global.common.ApiResponse;
 import com.pawstime.pawstime.global.enums.Status;
@@ -33,27 +35,30 @@ public class CommentController {
 
   private final CommentFacade commentFacade;
 
+
   @Operation(summary = "댓글 생성", description = "특정 게시글에 댓글을 생성하는 기능입니다.")
   @PostMapping("/{postId}")
-  public ResponseEntity<ApiResponse<Void>> createComment(
-      @PathVariable Long postId, @RequestBody CreateCommentReqDto req) {
+  public ResponseEntity<ApiResponse<CreateCommentRespDto>> createComment(
+          @PathVariable Long postId, @RequestBody CreateCommentReqDto req) {
     try {
-      commentFacade.createComment(postId, req);
+      // 댓글 생성 후 포맷된 응답 DTO 반환
+      CreateCommentRespDto responseDto = commentFacade.createComment(postId, req);
 
-      return ApiResponse.generateResp(Status.CREATE, "댓글 생성이 완료되었습니다.", null);
+      return ApiResponse.generateResp(Status.CREATE, "댓글 생성이 완료되었습니다.", responseDto);
 
     } catch (CustomException e) {
       Status status = Status.valueOf(e.getClass()
-          .getSimpleName()
-          .replace("Exception", "")
-          .toUpperCase());
+              .getSimpleName()
+              .replace("Exception", "")
+              .toUpperCase());
       return ApiResponse.generateResp(status, e.getMessage(), null);
 
     } catch (Exception e) {
       return ApiResponse.generateResp(
-          Status.ERROR, "댓글 생성 중 오류가 발생하였습니다 : " + e.getMessage(), null);
+              Status.ERROR, "댓글 생성 중 오류가 발생하였습니다 : " + e.getMessage(), null);
     }
   }
+
 
   @Operation(summary = "댓글 전체 목록 조회", description = "모든 게시글에 달린 댓글을 조회합니다.")
   @GetMapping("/listAll")

--- a/src/main/java/com/pawstime/pawstime/domain/comment/dto/req/CreateCommentReqDto.java
+++ b/src/main/java/com/pawstime/pawstime/domain/comment/dto/req/CreateCommentReqDto.java
@@ -10,6 +10,7 @@ public record CreateCommentReqDto(
 ) {
 
   public Comment of(Post post) {
+
     return Comment.builder()
         .post(post)
         .content(this.content)

--- a/src/main/java/com/pawstime/pawstime/domain/comment/dto/resp/CreateCommentRespDto.java
+++ b/src/main/java/com/pawstime/pawstime/domain/comment/dto/resp/CreateCommentRespDto.java
@@ -1,0 +1,19 @@
+package com.pawstime.pawstime.domain.comment.dto.resp;
+
+import com.pawstime.pawstime.domain.comment.entity.Comment;
+import lombok.Builder;
+
+@Builder
+public record CreateCommentRespDto(
+        Long id,
+        String content,
+        String createdAt // 포맷된 생성일자
+) {
+    public static CreateCommentRespDto from(Comment comment) {
+        return CreateCommentRespDto.builder()
+                .id(comment.getCommentId())  // 댓글 ID
+                .content(comment.getContent())  // 댓글 내용
+                .createdAt(comment.getFormattedCreatedAt())  // 포맷된 생성일자
+                .build();
+    }
+}

--- a/src/main/java/com/pawstime/pawstime/domain/comment/entity/Comment.java
+++ b/src/main/java/com/pawstime/pawstime/domain/comment/entity/Comment.java
@@ -16,6 +16,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.format.DateTimeFormatter;
+
 @Getter
 @Builder
 @Entity
@@ -34,4 +36,5 @@ public class Comment extends BaseEntity {
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "post_id")
   private Post post;
+
 }

--- a/src/main/java/com/pawstime/pawstime/domain/comment/entity/repository/CommentRepository.java
+++ b/src/main/java/com/pawstime/pawstime/domain/comment/entity/repository/CommentRepository.java
@@ -8,6 +8,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
@@ -19,4 +21,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
   @Query("SELECT c FROM Comment c WHERE c.post.postId = :postId AND c.isDelete = false")
   Page<Comment> findAllByPostQuery(Long postId, Pageable pageable);
+
+  Optional<Comment> findByPostAndContent(Post post, String content);
 }

--- a/src/main/java/com/pawstime/pawstime/domain/comment/service/CreateCommentService.java
+++ b/src/main/java/com/pawstime/pawstime/domain/comment/service/CreateCommentService.java
@@ -1,5 +1,6 @@
 package com.pawstime.pawstime.domain.comment.service;
 
+import com.pawstime.pawstime.domain.comment.dto.resp.CreateCommentRespDto;
 import com.pawstime.pawstime.domain.comment.entity.Comment;
 import com.pawstime.pawstime.domain.comment.entity.repository.CommentRepository;
 import lombok.RequiredArgsConstructor;
@@ -9,9 +10,11 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class CreateCommentService {
 
-  private final CommentRepository commentRepository;
+    private final CommentRepository commentRepository;
 
-  public void createComment(Comment comment) {
-    commentRepository.save(comment);
-  }
+    public Comment createComment(Comment comment) {
+        comment.getFormattedCreatedAt();
+
+        return commentRepository.save(comment);
+    }
 }

--- a/src/main/java/com/pawstime/pawstime/domain/image/entity/Image.java
+++ b/src/main/java/com/pawstime/pawstime/domain/image/entity/Image.java
@@ -21,7 +21,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "Image")
+@Table(name = "image")
 public class Image {
 
     @Id
@@ -40,7 +40,6 @@ public class Image {
 
     // 이미지를 Post에 추가하는 메서드
     public void setPost(Post post) {
-        System.out.println("*******************");
         this.post = post;
     }
 

--- a/src/main/java/com/pawstime/pawstime/domain/image/entity/repository/ImageRepository.java
+++ b/src/main/java/com/pawstime/pawstime/domain/image/entity/repository/ImageRepository.java
@@ -8,4 +8,5 @@ import java.util.List;
 
 public interface ImageRepository extends JpaRepository<Image, Long> {
     List<Image> findByPost_PostId(Long postId);
+    void deleteByImageUrl(String imageUrl);  // 이미지 URL로 삭제
 }

--- a/src/main/java/com/pawstime/pawstime/domain/post/service/CreatePostService.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/service/CreatePostService.java
@@ -13,7 +13,7 @@ public class CreatePostService {
 
   public void createPost(Post post){
 
-    //1.게시글 저장
+    post.getFormattedCreatedAt();
     postRepository.save(post);
 
   }

--- a/src/main/java/com/pawstime/pawstime/domain/post/service/UpdatePostService.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/service/UpdatePostService.java
@@ -16,7 +16,6 @@ public class UpdatePostService {
   public void updatePost(Post post, UpdatePostReqDto req) {
     post.setTitle(req.title());
     post.setContent(req.content());
-
     postRepository.save(post);
   }
 }

--- a/src/main/java/com/pawstime/pawstime/global/entity/BaseEntity.java
+++ b/src/main/java/com/pawstime/pawstime/global/entity/BaseEntity.java
@@ -4,6 +4,8 @@ import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -27,6 +29,24 @@ public abstract class BaseEntity {
 
   public void softDelete() {
     isDelete = true;
+  }
+
+  // 날짜 포맷팅 메서드 추가
+  public String getFormattedCreatedAt() {
+    return formatDate(createdAt);
+  }
+
+  public String getFormattedUpdatedAt() {
+    return formatDate(updatedAt);
+  }
+
+  // 공통 날짜 포맷팅 로직
+  private String formatDate(LocalDateTime dateTime) {
+    if (dateTime != null) {
+      DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+      return dateTime.format(formatter);
+    }
+    return null;
   }
 }
 


### PR DESCRIPTION
## 📝 설명 (Description)
댓글 생성 시 날짜 포맷을 `yyyy-MM-dd` 형식으로 변경했습니다. <br>
변경된 날짜 포맷을 `BaseEntity`에서 처리하고, `CreateCommentRespDto`를 통해 날짜 포맷을 반환하는 방식으로 구현했습니다.

--- 

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:
- [ ] `BaseEntity`에 날짜 포맷을 `yyyy-MM-dd`로 변경하는 기능 추가
- [ ] `CreateCommentRespDto` 추가: 요청(`CreateCommentReqDto`)에서 받은 날짜를 포맷한 후, 포맷된 날짜를 응답으로 반환
- [ ] `CreateCommentService`에서 날짜 포맷을 처리하는 로직 추가

---

## 📌 참고 사항 (Additional Notes)
추가적인 설명이나 주의해야 할 사항이 있다면 적어주세요.<br>
예: 의존성 추가, 환경 설정 변경 등.
