### PR TITLE
refact:게시글 이미지 삭제 수정

### DIFF
--- a/src/main/java/com/pawstime/pawstime/domain/comment/entity/repository/CommentRepository.java
+++ b/src/main/java/com/pawstime/pawstime/domain/comment/entity/repository/CommentRepository.java
@@ -23,4 +23,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
   Page<Comment> findAllByPostQuery(Long postId, Pageable pageable);
 
   Optional<Comment> findByPostAndContent(Post post, String content);
+
+  long countByPost(Post post);
 }

--- a/src/main/java/com/pawstime/pawstime/domain/comment/service/CreateCommentService.java
+++ b/src/main/java/com/pawstime/pawstime/domain/comment/service/CreateCommentService.java
@@ -14,7 +14,6 @@ public class CreateCommentService {
 
     public Comment createComment(Comment comment) {
         comment.getFormattedCreatedAt();
-
         return commentRepository.save(comment);
     }
 }

--- a/src/main/java/com/pawstime/pawstime/domain/post/dto/resp/GetDetailPostRespDto.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/dto/resp/GetDetailPostRespDto.java
@@ -1,8 +1,10 @@
 package com.pawstime.pawstime.domain.post.dto.resp;
 
+import com.pawstime.pawstime.domain.comment.entity.repository.CommentRepository;
 import com.pawstime.pawstime.domain.post.entity.Post;
 import java.time.LocalDateTime;
 import lombok.Builder;
+import org.springframework.beans.factory.annotation.Autowired;
 
 @Builder
 public record GetDetailPostRespDto(
@@ -11,11 +13,15 @@ public record GetDetailPostRespDto(
         String title,
         String content,
         LocalDateTime createdAt,
-        LocalDateTime updatedAt
-        //String nick  작성자 닉네임
+        LocalDateTime updatedAt,
+        Long commentCount // 댓글 수
+
 ) {
-    public static GetDetailPostRespDto from(Post post) {
-       // String nick = post.getUser() != null ? post.getUser().getNick() : "알 수 없음"; // 예시: 작성자 닉네임 처리
+
+
+    public static GetDetailPostRespDto from(Post post,  long commentCount) {
+
+
         return GetDetailPostRespDto.builder()
                 .bordId(post.getBoard().getBoardId())
                 .postId(post.getPostId())
@@ -23,7 +29,7 @@ public record GetDetailPostRespDto(
                 .content(post.getContent())
                 .createdAt(post.getCreatedAt())
                 .updatedAt(post.getUpdatedAt())
-               // .nick(nick)
+                .commentCount(commentCount)  // 댓글 수 포함
                 .build();
     }
 }

--- a/src/main/java/com/pawstime/pawstime/domain/post/entity/Post.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/entity/Post.java
@@ -111,7 +111,6 @@ public class Post extends BaseEntity {
   // 연관된 이미지 제거
   public void removeImage(Image image) {
     images.remove(image);
-    image.setPost(null);
   }
 
   public void setImages(List<Image> images) {

--- a/src/main/java/com/pawstime/pawstime/domain/post/service/CreatePostService.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/service/CreatePostService.java
@@ -13,7 +13,6 @@ public class CreatePostService {
 
   public void createPost(Post post){
 
-    post.getFormattedCreatedAt();
     postRepository.save(post);
 
   }

--- a/src/main/java/com/pawstime/pawstime/domain/post/service/GetDetailPostService.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/service/GetDetailPostService.java
@@ -1,5 +1,6 @@
 package com.pawstime.pawstime.domain.post.service;
 
+import com.pawstime.pawstime.domain.comment.entity.repository.CommentRepository;
 import com.pawstime.pawstime.domain.post.dto.resp.GetDetailPostRespDto;
 import com.pawstime.pawstime.domain.post.entity.Post;
 import com.pawstime.pawstime.domain.post.entity.repository.PostRepository;
@@ -10,15 +11,19 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class GetDetailPostService {
     private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
 
-    public GetDetailPostRespDto getDetailPost(Long postId){
+    public GetDetailPostRespDto getDetailPost(Long postId) {
         Post post = postRepository.findById(postId)
                 .orElse(null);
-        // 조회수 증가
-        post.increaseViews(); // 조회수 증가
+
+        post.increaseViews();
         postRepository.save(post); // 조회수가 증가된 게시글 저장
 
-        return GetDetailPostRespDto.from(post);  // DTO 반환
 
+        long commentCount = commentRepository.countByPost(post);
+
+        // DTO 반환 시 댓글 수 포함
+        return GetDetailPostRespDto.from(post, commentCount);
     }
 }

--- a/src/main/java/com/pawstime/pawstime/domain/post/service/S3Service.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/service/S3Service.java
@@ -66,12 +66,11 @@ public class S3Service {
         }
         return fileUrlList;
     }
+
     // 파일 이름 난수화
     public String createFileName(String fileName) {
         System.out.println("파일 이름 난수화");
         return UUID.randomUUID().toString().concat(getFileExtension(fileName));
-
-
     }
 
     // 파일 이름 정리
@@ -98,12 +97,8 @@ public class S3Service {
 
     }
 
-    /**
-     * 파일 삭제 메서드
-     *
-     * @param fileName S3 버킷에 저장된 파일 이름
-     */
     public void deleteFile(String fileName) {
-        amazonS3.deleteObject(new DeleteObjectRequest(bucket, fileName));
+        // S3에서 파일 삭제
+        amazonS3.deleteObject(new DeleteObjectRequest(bucket, String.valueOf(fileName)));
     }
 }


### PR DESCRIPTION
📝 설명 (Description)

이번 변경은 게시글 삭제 시 S3에서 파일을 삭제하고, Post 엔티티에서 이미지를 제거할 때 발생하는 오류를 해결하기 위한 변경입니다. orphanRemoval 설정을 활용하여 이미지를 자동으로 삭제하도록 처리했습니다.

🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:

 Post 엔티티의 images 필드에 orphanRemoval = true를 설정하여, 부모 Post가 이미지 목록을 비울 때 이미지를 자동으로 삭제하도록 처리.

 게시글 삭제 시 이미지 목록을 clear()로 비워서 Hibernate가 orphan된 이미지를 자동으로 삭제하도록 수정.

 이미지 URL을 기반으로 S3에서 파일을 삭제하도록 로직 추가.

📌 참고 사항 (Additional Notes)
orphanRemoval = true가 설정된 경우, 부모 엔티티에서 자식 엔티티를 더 이상 참조하지 않으면 자식 엔티티는 자동으로 삭제됩니다.
이미지 삭제 후 게시글의 상태를 저장하는 부분에서 save 대신 softDelete 처리를 통해 논리적 삭제를 구현하였습니다.