### PR TITLE
feat: 게시글별 대표 이미지 조회 (썸네일) 기능

### DIFF
--- a/src/main/java/com/pawstime/pawstime/domain/image/dto/resp/GetImageRespDto.java
+++ b/src/main/java/com/pawstime/pawstime/domain/image/dto/resp/GetImageRespDto.java
@@ -1,0 +1,20 @@
+package com.pawstime.pawstime.domain.image.dto.resp;
+
+import com.pawstime.pawstime.domain.image.entity.Image;
+import lombok.Builder;
+
+@Builder
+public record GetImageRespDto(
+    Long imageId,
+    String imageUrl,
+    Long postId
+) {
+
+  public static GetImageRespDto from(Image image) {
+    return GetImageRespDto.builder()
+        .imageId(image.getImageId())
+        .imageUrl(image.getImageUrl())
+        .postId(image.getPost().getPostId())
+        .build();
+  }
+}

--- a/src/main/java/com/pawstime/pawstime/domain/image/entity/repository/ImageRepository.java
+++ b/src/main/java/com/pawstime/pawstime/domain/image/entity/repository/ImageRepository.java
@@ -1,12 +1,19 @@
 package com.pawstime.pawstime.domain.image.entity.repository;
 
+import com.pawstime.pawstime.domain.image.dto.resp.GetImageRespDto;
 import com.pawstime.pawstime.domain.image.entity.Image;
 import com.pawstime.pawstime.domain.post.entity.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ImageRepository extends JpaRepository<Image, Long> {
     List<Image> findByPost_PostId(Long postId);
     void deleteByImageUrl(String imageUrl);  // 이미지 URL로 삭제
+
+  @Query("SELECT i FROM Image i WHERE i.post.postId = :postId")
+  Page<Image> getThumbnail(Long postId, Pageable pageable);
 }

--- a/src/main/java/com/pawstime/pawstime/domain/image/service/ReadImageService.java
+++ b/src/main/java/com/pawstime/pawstime/domain/image/service/ReadImageService.java
@@ -1,0 +1,21 @@
+package com.pawstime.pawstime.domain.image.service;
+
+import com.pawstime.pawstime.domain.image.dto.resp.GetImageRespDto;
+import com.pawstime.pawstime.domain.image.entity.Image;
+import com.pawstime.pawstime.domain.image.entity.repository.ImageRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ReadImageService {
+
+  private final ImageRepository imageRepository;
+
+  public Page<Image> getThumbnail(Long postId, Pageable pageable) {
+    return imageRepository.getThumbnail(postId, pageable);
+  }
+}

--- a/src/main/java/com/pawstime/pawstime/domain/post/controller/PostController.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/controller/PostController.java
@@ -1,6 +1,7 @@
 package com.pawstime.pawstime.domain.post.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pawstime.pawstime.domain.image.dto.resp.GetImageRespDto;
 import com.pawstime.pawstime.domain.like.facade.LikeFacade;
 import com.pawstime.pawstime.domain.post.dto.req.CreatePostReqDto;
 import com.pawstime.pawstime.domain.post.dto.req.UpdatePostReqDto;
@@ -174,6 +175,23 @@ public class PostController {
         }
     }
 
+    @Operation(summary = "게시글별 대표 이미지 조회")
+    @GetMapping("/{postId}/thumbnail")
+    public ResponseEntity<ApiResponse<List<GetImageRespDto>>> getThumbnail(@PathVariable Long postId) {
+        try {
+            return ApiResponse.generateResp(Status.SUCCESS, null, postFacade.getThumbnail(postId).getContent());
+        } catch (CustomException e) {
+            Status status = Status.valueOf(e.getClass()
+                .getSimpleName()
+                .replace("Exception", "")
+                .toUpperCase());
+            return ApiResponse.generateResp(status, e.getMessage(), null);
+
+        } catch (Exception e) {
+            return ApiResponse.generateResp(
+                Status.ERROR, "게시판 상세조회 중 오류가 발생하였습니다 : " + e.getMessage(), null);
+        }
+    }
 
     // Pageable 객체 생성 (정렬 처리)
     public Pageable createPageable(String sort, int page, int size) {

--- a/src/main/java/com/pawstime/pawstime/domain/post/facade/PostFacade.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/facade/PostFacade.java
@@ -1,8 +1,10 @@
 package com.pawstime.pawstime.domain.post.facade;
 
 import com.pawstime.pawstime.domain.board.entity.Board;
+import com.pawstime.pawstime.domain.image.dto.resp.GetImageRespDto;
 import com.pawstime.pawstime.domain.image.entity.Image;
 import com.pawstime.pawstime.domain.image.entity.repository.ImageRepository;
+import com.pawstime.pawstime.domain.image.service.ReadImageService;
 import com.pawstime.pawstime.domain.post.dto.req.CreatePostReqDto;
 import com.pawstime.pawstime.domain.post.dto.req.UpdatePostReqDto;
 import com.pawstime.pawstime.domain.post.dto.resp.GetDetailPostRespDto;
@@ -26,6 +28,8 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -45,6 +49,7 @@ public class PostFacade {
     private final PostRepository postRepository;
     private final S3Service s3Service;
     private final ImageRepository imageRepository;
+    private final ReadImageService readImageService;
 
     public void createPost(CreatePostReqDto req, List<String> imageUrls) {
         // 입력값 검증
@@ -199,4 +204,23 @@ public class PostFacade {
         return imageUrl.substring(imageUrl.lastIndexOf("/") + 1);
     }
 
+  public Page<GetImageRespDto> getThumbnail(Long postId) {
+      Post post = readPostService.findPostId(postId);
+
+      if (post == null || post.isDelete()) {
+          throw new NotFoundException("존재하지 않거나 삭제된 게시글입니다.");
+      }
+
+      Pageable pageable = PageRequest.of(0, 1);
+      // 게시글에 있는 이미지 중 제일 첫번째 이미지만 가져오도록 Pageable사용
+
+      Page<GetImageRespDto> thumbnail = readImageService.getThumbnail(postId, pageable).map(GetImageRespDto::from);
+
+      if (thumbnail.isEmpty()) {
+          GetImageRespDto defaultImage = new GetImageRespDto(null, "https://paws-time-bucket.s3.ap-northeast-2.amazonaws.com/a6666d57-bcc5-4a30-93b7-81d58ae4d5fd.jpg", postId);
+          return new PageImpl<>(List.of(defaultImage), pageable, 1);
+      }
+
+      return thumbnail;
+  }
 }


### PR DESCRIPTION
## 📝 설명 (Description)
게시글별 대표 이미지를 조회하는 기능을 추가하였습니다.
게시글의 이미지들 중 첫 번째 이미지를 썸네일로 사용하며, 이미지가 없는 경우 기본 이미지를 반환합니다.

--- 

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:
- [x] 변경사항 1 : 게시글 썸네일 조회 기능 추가 - pageable을 이용하여 pageNo=0, pageSize=1로 설정하여 게시글에 여러 이미지가 있어도 하나의 이미지만 가져올 수 있도록 하였습니다.
- [x] 변경사항 2 : 기본 이미지 설정 - 게시글에 이미지가 없는 경우, 미리 업로드한 S3 기본 이미지를 반환하도록 구현하였습니.

---

## 📌 참고 사항 (Additional Notes)
현재는 S3에 업로드된 사진 중 하나를 기본 이미지로 지정했지만,
향후 이미지가 없을 경우 보여줄 default 이미지를 제작하여 해당 URL로 업데이트하는 것이 필요합니다.
