### PR TITLE
feat: 게시글별 이미지 전체 조회 기능

### DIFF
--- a/src/main/java/com/pawstime/pawstime/domain/image/entity/repository/ImageRepository.java
+++ b/src/main/java/com/pawstime/pawstime/domain/image/entity/repository/ImageRepository.java
@@ -16,4 +16,7 @@ public interface ImageRepository extends JpaRepository<Image, Long> {
 
   @Query("SELECT i FROM Image i WHERE i.post.postId = :postId")
   Page<Image> getThumbnail(Long postId, Pageable pageable);
+
+  @Query("SELECT i FROM Image i WHERE i.post.postId = :postId")
+  List<Image> getImages(Long postId);
 }

--- a/src/main/java/com/pawstime/pawstime/domain/image/service/ReadImageService.java
+++ b/src/main/java/com/pawstime/pawstime/domain/image/service/ReadImageService.java
@@ -18,4 +18,8 @@ public class ReadImageService {
   public Page<Image> getThumbnail(Long postId, Pageable pageable) {
     return imageRepository.getThumbnail(postId, pageable);
   }
+
+  public List<Image> getImages(Long postId) {
+    return imageRepository.getImages(postId);
+  }
 }

--- a/src/main/java/com/pawstime/pawstime/domain/post/controller/PostController.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/controller/PostController.java
@@ -189,7 +189,25 @@ public class PostController {
 
         } catch (Exception e) {
             return ApiResponse.generateResp(
-                Status.ERROR, "게시판 상세조회 중 오류가 발생하였습니다 : " + e.getMessage(), null);
+                Status.ERROR, "썸네일 이미지 조회 중 오류가 발생하였습니다 : " + e.getMessage(), null);
+        }
+    }
+
+    @Operation(summary = "게시글별 이미지 전체 조회")
+    @GetMapping("/{postId}/images")
+    public ResponseEntity<ApiResponse<List<GetImageRespDto>>> getImages(@PathVariable Long postId) {
+        try {
+            return ApiResponse.generateResp(Status.SUCCESS, null, postFacade.getImages(postId));
+        } catch (CustomException e) {
+            Status status = Status.valueOf(e.getClass()
+                .getSimpleName()
+                .replace("Exception", "")
+                .toUpperCase());
+            return ApiResponse.generateResp(status, e.getMessage(), null);
+
+        } catch (Exception e) {
+            return ApiResponse.generateResp(
+                Status.ERROR, "게시글별 이미지 전체 조회 중 오류가 발생하였습니다 : " + e.getMessage(), null);
         }
     }
 

--- a/src/main/java/com/pawstime/pawstime/domain/post/facade/PostFacade.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/facade/PostFacade.java
@@ -223,4 +223,21 @@ public class PostFacade {
 
       return thumbnail;
   }
+
+    public List<GetImageRespDto> getImages(Long postId) {
+        Post post = readPostService.findPostId(postId);
+
+        if (post == null || post.isDelete()) {
+            throw new NotFoundException("존재하지 않거나 삭제된 게시글입니다.");
+        }
+
+        List<Image> images = readImageService.getImages(postId);
+
+        if (images.isEmpty()) {
+            GetImageRespDto defaultImage = new GetImageRespDto(null, "https://paws-time-bucket.s3.ap-northeast-2.amazonaws.com/a6666d57-bcc5-4a30-93b7-81d58ae4d5fd.jpg", postId);
+            return List.of(defaultImage);
+        }
+
+        return images.stream().map(GetImageRespDto::from).toList();
+    }
 }


### PR DESCRIPTION
## 📝 설명 (Description)
게시글에 첨부된 이미지들을 전체 조회하는 기능을 추가하였습니다.
이미지가 없는 경우, 기본 이미지를 반환하도록 구현하였습니다.

--- 

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:
- [x] 변경사항 1 : 게시글 이미지 전체 조회 기능 추가 - 게시글에 첨부된 이미지를 List<>로 모두 반환하도록 구현하였습니다.
- [x] 변경사항 2 : 기본 이미지 반환 로직 추가 - 게시글에 이미지가 없는 경우, 기본 이미지를 반환하도록 구현하였습니다.

---

## 📌 참고 사항 (Additional Notes)
향후 이미지가 없을 경우 보여줄 default 이미지를 제작하여 해당 URL로 업데이트하는 것이 필요합니다.
