### PR TITLE
게시글의 기존 이미지 삭제 및 ì¶새로운 이미지 추가

### DIFF
--- a/src/main/java/com/pawstime/pawstime/domain/image/service/UpdateImageService.java
+++ b/src/main/java/com/pawstime/pawstime/domain/image/service/UpdateImageService.java
@@ -1,0 +1,88 @@
+package com.pawstime.pawstime.domain.image.service;
+
+import com.pawstime.pawstime.domain.image.entity.Image;
+import com.pawstime.pawstime.domain.image.entity.repository.ImageRepository;
+import com.pawstime.pawstime.domain.post.entity.Post;
+import com.pawstime.pawstime.domain.post.service.S3Service;
+import com.pawstime.pawstime.global.exception.NotFoundException;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateImageService {
+
+    private final ImageRepository imageRepository;
+    private final S3Service s3Service;
+
+    @Transactional
+    public List<Long> deleteImagesFromPost(List<Long> deletedImageIds, Post post) {
+        List<Long> deletedImageIdsList = new ArrayList<>();
+
+        for (Long imageId : deletedImageIds) {
+            Image image = imageRepository.findById(imageId)
+                    .orElseThrow(() -> new NotFoundException("존재하지 않는 이미지 ID입니다."));
+
+            String imageUrl = image.getImageUrl();
+            String fileName = extractFileNameFromUrl(imageUrl);
+
+            // S3에서 파일 삭제
+            try {
+                s3Service.deleteFile(fileName);
+            } catch (Exception e) {
+                throw new RuntimeException("S3 파일 삭제 실패: " + fileName, e);
+            }
+
+            post.getImages().remove(image);
+            imageRepository.delete(image);
+            deletedImageIdsList.add(imageId);
+        }
+
+        return deletedImageIdsList;
+    }
+
+    @Transactional
+    public List<Map<String, Object>> addNewImagesToPost(List<MultipartFile> newImages, Post post) {
+        List<Map<String, Object>> addedImages = new ArrayList<>();
+
+        for (MultipartFile newImage : newImages) {
+            String uploadedUrl;
+            try {
+                uploadedUrl = s3Service.uploadFile(Collections.singletonList(newImage)).get(0);
+            } catch (Exception e) {
+                throw new RuntimeException("S3 업로드 실패", e);
+            }
+
+            Image image = Image.builder()
+                    .imageUrl(uploadedUrl)
+                    .post(post)
+                    .build();
+
+            imageRepository.save(image);
+            post.getImages().add(image);
+
+            Map<String, Object> imageInfo = new HashMap<>();
+            imageInfo.put("imageId", image.getImageId());
+            imageInfo.put("imageUrl", uploadedUrl);
+            addedImages.add(imageInfo);
+        }
+
+        return addedImages;
+    }
+
+    public String extractFileNameFromUrl(String imageUrl) {
+        try {
+            URL url = new URL(imageUrl);
+            String path = url.getPath();
+            return path.substring(path.lastIndexOf("/") + 1);
+        } catch (MalformedURLException e) {
+            throw new RuntimeException("잘못된 URL입니다: " + imageUrl, e);
+        }
+    }
+}

--- a/src/main/java/com/pawstime/pawstime/domain/post/controller/PostController.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/controller/PostController.java
@@ -101,11 +101,12 @@ public class PostController {
     }
 
     @Operation(summary = "게시글 수정", description = "게시글을 수정할 수 있습니다.")
-    @PutMapping("/{postId}")
-    public ResponseEntity<ApiResponse<Void>> updatePost(@Valid @PathVariable Long postId,
-                                                        @RequestBody UpdatePostReqDto req) {
+    @PutMapping( "/{postId}")
+    public ResponseEntity<ApiResponse<Void>> updatePost(
+            @PathVariable Long postId,
+            @Valid @ModelAttribute UpdatePostReqDto req
+    ) {
         try {
-            // Facade에서 예외를 던지도록 처리
             postFacade.updatePost(postId, req);
             return ApiResponse.generateResp(Status.UPDATE, "게시글 수정이 완료되었습니다.", null);
         } catch (CustomException e) {
@@ -116,6 +117,26 @@ public class PostController {
             return ApiResponse.generateResp(Status.ERROR, "게시글 수정 중 오류가 발생하였습니다: " + e.getMessage(), null);
         }
     }
+
+    @Operation(summary = "게시글 이미지 수정", description = "기존 이미지를 삭제하거나 새로운 이미지를 추가합니다.")
+    @PutMapping(value = "/{postId}/images", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<Void>> updatePostImages(
+            @PathVariable Long postId,
+            @RequestParam(value = "deletedImageIds", required = false) List<Long> deletedImageIds,
+            @RequestPart(value = "newImages", required = false) List<MultipartFile> newImages) {
+
+        try {
+            // 이미지 수정 요청 처리
+            postFacade.updatePostImages(postId, deletedImageIds, newImages);
+
+            return ApiResponse.generateResp(Status.UPDATE, "게시글 이미지가 수정되었습니다.", null);
+        } catch (Exception e) {
+            log.error("게시글 이미지 수정 중 오류 발생: {}", e.getMessage(), e);
+            return ApiResponse.generateResp(Status.ERROR, "이미지 수정 실패: " + e.getMessage(), null);
+        }
+    }
+
+
 
     @Operation(summary = "게시글 삭제", description = "게시글을 삭제할 수 있습니다.")
     @DeleteMapping("/{postId}")

--- a/src/main/java/com/pawstime/pawstime/domain/post/dto/req/UpdatePostReqDto.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/dto/req/UpdatePostReqDto.java
@@ -13,11 +13,6 @@ public record UpdatePostReqDto(
         String title,
         @Schema(description = "게시글 내용", example = "일상 내용")
         @NotBlank(message = "내용은 비어 있을 수 없습니다.")
-        String content,
-        @Schema(description = "삭제할 이미지 ID 목록", example = "[1, 2, 3]")
-        List<Long> deletedImageIds, // 삭제할 이미지 ID 목록
-        @Schema(description = "추가할 이미지 파일", example = "image1.jpg, image2.jpg")
-        List<MultipartFile> newImages // 새로 추가할 이미지 파일
-
+        String content
 ) {
 }

--- a/src/main/java/com/pawstime/pawstime/domain/post/entity/Post.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/entity/Post.java
@@ -113,13 +113,5 @@ public class Post extends BaseEntity {
   }
 
 
-  public Post updateContent(String title, String content) {
-    if (title != null) {
-      this.title = title;
-    }
-    if (content != null) {
-      this.content = content;
-    }
-    return this; // 업데이트된 엔티티를 반환
-  }
+
 }


### PR DESCRIPTION
## 📝 설명 (Description)
간단하게 무엇을 변경했는지 설명해주세요. <br>
게시글에 이미지를 추가하는 기능을 구현했습니다. 사용자가 새로운 이미지를 업로드할 수 있도록 하고, 기존 이미지는 삭제하거나 업데이트할 수 있는 기능도 추가했습니다. 이 변경을 통해 게시글에 이미지 추가 및 삭제가 원활히 처리될 수 있습니다.


--- 

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:
- [ ] 변경사항 1 : 게시글 이미지 추가 기능 구현: 사용자가 새로운 이미지를 게시글에 추가할 수 있도록 처리했습니다.
- [ ] 변경사항 2 : 게시글 이미지 삭제 기능 구현: 사용자가 지정한 이미지 ID를 통해 기존 이미지를 삭제하는 기능을 추가했습니다.
- [ ] updatePostImages API 업데이트: newImages와 deletedImageIds 파라미터를 받아 처리할 수 있도록 API를 수정했습니다.
- [ ] 응답에 추가된 이미지 URL과 삭제된 이미지 ID를 포함하도록 수정했습니다.


---

## 📌 참고 사항 (Additional Notes)
추가적인 설명이나 주의해야 할 사항이 있다면 적어주세요.<br>
예: 의존성 추가, 환경 설정 변경 등.
