### PR TITLE
feat: 메인페이지용 랜덤 이미지 조회

### DIFF
--- a/src/main/java/com/pawstime/pawstime/domain/image/entity/repository/ImageRepository.java
+++ b/src/main/java/com/pawstime/pawstime/domain/image/entity/repository/ImageRepository.java
@@ -19,4 +19,7 @@ public interface ImageRepository extends JpaRepository<Image, Long> {
 
   @Query("SELECT i FROM Image i WHERE i.post.postId = :postId")
   List<Image> getImages(Long postId);
+
+  @Query("SELECT i FROM Image i ORDER BY RAND()")
+  Page<Image> getRandomImages(Pageable pageable);
 }

--- a/src/main/java/com/pawstime/pawstime/domain/image/service/ReadImageService.java
+++ b/src/main/java/com/pawstime/pawstime/domain/image/service/ReadImageService.java
@@ -22,4 +22,8 @@ public class ReadImageService {
   public List<Image> getImages(Long postId) {
     return imageRepository.getImages(postId);
   }
+
+  public Page<Image> getRandomImages(Pageable pageable) {
+    return imageRepository.getRandomImages(pageable);
+  }
 }

--- a/src/main/java/com/pawstime/pawstime/domain/post/controller/PostController.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/controller/PostController.java
@@ -211,6 +211,24 @@ public class PostController {
         }
     }
 
+    @Operation(summary = "메인페이지에서 사용할 랜덤 이미지 조회")
+    @GetMapping("/images/random")
+    public ResponseEntity<ApiResponse<List<GetImageRespDto>>> getRandomImages() {
+        try {
+            return ApiResponse.generateResp(Status.SUCCESS, null, postFacade.getRandomImages().getContent());
+        } catch (CustomException e) {
+            Status status = Status.valueOf(e.getClass()
+                .getSimpleName()
+                .replace("Exception", "")
+                .toUpperCase());
+            return ApiResponse.generateResp(status, e.getMessage(), null);
+
+        } catch (Exception e) {
+            return ApiResponse.generateResp(
+                Status.ERROR, "랜덤 이미지 조회 중 오류가 발생하였습니다 : " + e.getMessage(), null);
+        }
+    }
+
     // Pageable 객체 생성 (정렬 처리)
     public Pageable createPageable(String sort, int page, int size) {
         String[] sortParams = sort.split(",");

--- a/src/main/java/com/pawstime/pawstime/domain/post/facade/PostFacade.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/facade/PostFacade.java
@@ -240,4 +240,11 @@ public class PostFacade {
 
         return images.stream().map(GetImageRespDto::from).toList();
     }
+
+    public Page<GetImageRespDto> getRandomImages() {
+        Pageable pageable = PageRequest.of(0, 5);
+        // 전체 이미지 중 5개의 이미지만 가져오도록 Pageable사용 (repository에서 랜덤으로 정렬한 후 5개만 가져옴)
+
+        return readImageService.getRandomImages(pageable).map(GetImageRespDto::from);
+    }
 }


### PR DESCRIPTION
## 📝 설명 (Description)
메인 페이지에서 사용할 전체 이미지 중 랜덤으로 5개를 가져오는 기능을 구현했습니다.
이 변경은 메인 페이지에 랜덤 이미지를 표시하는 목적입니다.

--- 

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:
- [x] 변경사항 1 :  JPQL @Query에서 RAND()를 사용해 이미지를 랜덤으로 정렬합니다.
- [x] 변경사항 2 : Pageable을 사용하여 pageNum: 0, pageSize: 5로 5개 이미지만 가져오도록 설정했습니다.
- [x] 변경사항 3 : 전체 이미지가 5개 미만일 경우, 해당 개수만큼 이미지를 반환하도록 처리했습니다.

---

## 📌 참고 사항 (Additional Notes)

