### PR TITLE
fix: 댓글 내용 중복시 발생하는 오류 수정

### DIFF
--- a/src/main/java/com/pawstime/pawstime/domain/comment/entity/repository/CommentRepository.java
+++ b/src/main/java/com/pawstime/pawstime/domain/comment/entity/repository/CommentRepository.java
@@ -22,7 +22,5 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
   @Query("SELECT c FROM Comment c WHERE c.post.postId = :postId AND c.isDelete = false")
   Page<Comment> findAllByPostQuery(Long postId, Pageable pageable);
 
-  Optional<Comment> findByPostAndContent(Post post, String content);
-
   long countByPost(Post post);
 }

--- a/src/main/java/com/pawstime/pawstime/domain/comment/facade/CommentFacade.java
+++ b/src/main/java/com/pawstime/pawstime/domain/comment/facade/CommentFacade.java
@@ -28,7 +28,6 @@ public class CommentFacade {
 
   private final ReadCommentService readCommentService;
   private final CreateCommentService createCommentService;
-  private final CommentRepository commentRepository;
 
   public CreateCommentRespDto createComment(Long postId, CreateCommentReqDto req) {
     Post post = readCommentService.getPostById(postId);
@@ -52,9 +51,6 @@ public class CommentFacade {
 
     // 새로운 댓글 생성
     Comment createdComment = createCommentService.createComment(comment);
-    // 댓글을 데이터베이스에서 다시 조회
-    createdComment = commentRepository.findByPostAndContent(post, req.content())
-            .orElseThrow(() -> new NotFoundException("댓글 생성 후 조회 실패"));
 
     // 생성된 댓글을 기반으로 응답 DTO 생성
     return CreateCommentRespDto.from(createdComment); // 응답 DTO 반환


### PR DESCRIPTION
## 📝 설명 (Description)
댓글 생성 시 중복 댓글을 허용하도록 로직을 수정하였습니다. 

--- 

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:
- [x] 변경사항 1 : 기존에는 동일한 내용의 댓글을 작성할 수 없도록 findByPostAndContent 메소드로 중복을 검사하고 있었으나, 이 검사를 제거하여 사용자가 동일한 내용의 댓글을 여러 번 작성할 수 있게 변경했습니다.

---

## 📌 참고 사항 (Additional Notes)
기존에는 동일한 내용의 댓글을 작성할 경우 예외가 발생했으나, 이제는 중복 댓글이 허용됩니다.
댓글 내용이 중복되는 상황에서도 정상적으로 댓글이 작성됩니다.
