### PR TITLE
refactor: RESTful URL 구조 개선 및 게시글 접근 권한 설정

### DIFF
--- a/src/main/java/com/pawstime/pawstime/domain/board/controller/BoardController.java
+++ b/src/main/java/com/pawstime/pawstime/domain/board/controller/BoardController.java
@@ -25,7 +25,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
-@Tag(name = "Board", description = "게사판 API")
+@Tag(name = "Board", description = "게시판 API")
 @RestController
 @RequestMapping("/boards")
 @RequiredArgsConstructor

--- a/src/main/java/com/pawstime/pawstime/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/pawstime/pawstime/domain/comment/controller/CommentController.java
@@ -29,7 +29,6 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 @Tag(name = "Comment", description = "댓글 API")
 @RestController
-@RequestMapping("/comments")
 @RequiredArgsConstructor
 public class CommentController {
 
@@ -37,7 +36,7 @@ public class CommentController {
 
 
   @Operation(summary = "댓글 생성", description = "특정 게시글에 댓글을 생성하는 기능입니다.")
-  @PostMapping("/{postId}")
+  @PostMapping("/posts/{postId}/comments")
   public ResponseEntity<ApiResponse<CreateCommentRespDto>> createComment(
           @PathVariable Long postId, @RequestBody CreateCommentReqDto req) {
     try {
@@ -61,7 +60,7 @@ public class CommentController {
 
 
   @Operation(summary = "댓글 전체 목록 조회", description = "모든 게시글에 달린 댓글을 조회합니다.")
-  @GetMapping("/listAll")
+  @GetMapping("/comments")
   public ResponseEntity<ApiResponse<List<GetCommentRespDto>>> getCommentAll(
       @RequestParam(defaultValue = "0") int pageNo,
       @RequestParam(defaultValue = "10") int pageSize,
@@ -86,7 +85,7 @@ public class CommentController {
   }
 
   @Operation(summary = "특정 게시글 댓글 조회", description = "선택한 게시글에 달린 댓글 목록을 조회합니다.")
-  @GetMapping("/list/{postId}")
+  @GetMapping("/posts/{postId}/comments")
   public ResponseEntity<ApiResponse<List<GetCommentRespDto>>> getCommentByPost(
       @PathVariable Long postId,
       @RequestParam(defaultValue = "0") int pageNo,
@@ -112,10 +111,10 @@ public class CommentController {
   }
 
   @Operation(summary = "댓글 삭제", description = "선택한 댓글을 삭제합니다.")
-
-  @DeleteMapping("/{commentId}")
-
-  public ResponseEntity<ApiResponse<Void>> deleteComment(@PathVariable Long commentId) {
+  @DeleteMapping("/posts/{postId}/comments/{commentId}")
+  public ResponseEntity<ApiResponse<Void>> deleteComment(
+      @PathVariable Long postId, @PathVariable Long commentId
+  ) {
     try {
 
       commentFacade.deleteComment(commentId);
@@ -134,9 +133,12 @@ public class CommentController {
           Status.ERROR, "댓글 삭제 중 오류가 발생하였습니다 : " + e.getMessage(), null);
     }
   }
+
   @Operation(summary = "댓글 수정", description = "선택한 댓글을 수정합니다.")
-  @PutMapping("/{commentId}")
-  public ResponseEntity<ApiResponse<Void>> updateComment( @PathVariable Long commentId, @RequestBody UpdateCommentReqDto req){
+  @PutMapping("/posts/{postId}/comments/{commentId}")
+  public ResponseEntity<ApiResponse<Void>> updateComment(
+      @PathVariable Long postId, @PathVariable Long commentId, @RequestBody UpdateCommentReqDto req
+  ){
    try{
      commentFacade.updateComment(commentId, req);
      return ApiResponse.generateResp(
@@ -151,7 +153,6 @@ public class CommentController {
    } catch (Exception e) {
      return ApiResponse.generateResp(
              Status.ERROR, "댓글 수정 중 오류가 발생했습니다. : " + e.getMessage(), null);
-
    }
   }
 }

--- a/src/main/java/com/pawstime/pawstime/domain/post/controller/PostController.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/controller/PostController.java
@@ -39,7 +39,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Slf4j
 @Tag(name = "Post", description = "게시글 API")
 @RestController
-@RequestMapping("/post")
+@RequestMapping("/posts")
 @RequiredArgsConstructor
 public class PostController {
 

--- a/src/main/java/com/pawstime/pawstime/domain/post/facade/PostFacade.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/facade/PostFacade.java
@@ -150,6 +150,9 @@ public class PostFacade {
         // 게시글 조회
         Post post = readPostService.findPostById(postId);
 
+        // ******** 게시글 작성자 확인 후 게시글 수정을 요청한 유저가 해당 게시글을 작성한 유저와 일치하는지
+        // 아니면 관리자 권한을 가지고 있는지 확인하는 로직 추가 필요 ********
+
         // 게시글 존재 여부 및 삭제 상태 확인
         if (post == null) {
             throw new NotFoundException("존재하지 않는 게시글 ID입니다.");

--- a/src/main/java/com/pawstime/pawstime/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/pawstime/pawstime/global/config/security/SecurityConfig.java
@@ -40,12 +40,12 @@ public class SecurityConfig {
 
   // 로그인 한 사용자(관리자 + 일반유저)만 접근을 허용하는 경로
   private static final String[] ADMIN_USER_ONLY = {
-    "/users/logout"//, "/post/**/likes"
+    "/users/logout", "/post/{postId}/likes"
   };
 
   // 모든 사용자에게 접근을 허용하는 경로
   private static final String[] PUBLIC_ALL = {
-    "/users", "/users/login"//, "/post/**/thumbnail", "/post/images/random"
+    "/users", "/users/login", "/post/{postId}/thumbnail", "/post/images/random"
   };
 
   @Bean
@@ -70,17 +70,17 @@ public class SecurityConfig {
             .requestMatchers(PUBLIC_ALL).permitAll()
 
             .requestMatchers(HttpMethod.POST, "/boards").hasRole("ADMIN")   // 게시판 생성 => 관리자만 가능하도록 함
-            .requestMatchers(HttpMethod.DELETE, "/boards/**").hasRole("ADMIN")   // 게시판 삭제 => 관리자만 가능하도록 함
-            .requestMatchers(HttpMethod.PUT, "/boards/**").hasRole("ADMIN")   // 게시판 수정 => 관리자만 가능하도록 함
-            .requestMatchers(HttpMethod.GET, "/boards", "/boards/**").permitAll()   // 게시판 목록조회,상세조회 => 모두 접근 가능
+            .requestMatchers(HttpMethod.DELETE, "/boards/{boardId}").hasRole("ADMIN")   // 게시판 삭제 => 관리자만 가능하도록 함
+            .requestMatchers(HttpMethod.PUT, "/boards/{boardId}").hasRole("ADMIN")   // 게시판 수정 => 관리자만 가능하도록 함
+            .requestMatchers(HttpMethod.GET, "/boards", "/boards/{boardId}").permitAll()   // 게시판 목록조회,상세조회 => 모두 접근 가능
 
-            //.requestMatchers(HttpMethod.POST, "/post", "/post/**").hasAnyRole("ADMIN", "USER")
-            //.requestMatchers(HttpMethod.PUT, "/post/**", "/post/**/images").hasAnyRole("ADMIN", "USER")
-            //.requestMatchers(HttpMethod.DELETE, "/post/**").hasAnyRole("ADMIN", "USER")
-            //.requestMatchers(HttpMethod.GET, "/post", "/post/**", "/post/**/images").permitAll()
+            .requestMatchers(HttpMethod.POST, "/post", "/post/{postId}").hasAnyRole("ADMIN", "USER")  // 게시글 생성, 게시글 이미지 업로드(생성) => 관리자,일반유저만 접근 가능
+            .requestMatchers(HttpMethod.PUT, "/post/{postId}", "/post/{postId}/images").hasAnyRole("ADMIN", "USER")   // 게시글 수정, 게시글 이미지 수정 => 관리자,일반유저만 접근 가능
+            .requestMatchers(HttpMethod.DELETE, "/post/{postId}").hasAnyRole("ADMIN", "USER")   // 게시글 삭제 => 관리자,일반유저만 접근 가능
+            .requestMatchers(HttpMethod.GET, "/post", "/post/{postId}", "/post/{postId}/images").permitAll()  // 게시글 전체 목록 조회, 게시글 상세 조회, 게시글 이미지 조회 => 모두 접근 가능
 
-            .anyRequest().authenticated())  // 그 외 요청은 로그인된 사용자만 접근 가능
-            //.anyRequest().permitAll())   // 그 외 요청 모두 접근 가능 (로그인을 하지 않아도 모든 요청을 허용 => 보안을 위해 하지 않는 것이 좋다)
+            //.anyRequest().authenticated())  // 그 외 요청은 로그인된 사용자만 접근 가능
+            .anyRequest().permitAll())   // 그 외 요청 모두 접근 가능 (로그인을 하지 않아도 모든 요청을 허용 => 보안을 위해 하지 않는 것이 좋다)
         .build();
   }
 }


### PR DESCRIPTION
## 📝 설명 (Description)
이번 PR에서는 RESTful한 URL 구조로 개선, 게시글 및 댓글 API 엔드포인트 명확화, 게시글 CRUD 접근 권한 설정 등의 변경 사항을 적용하였습니다.
주된 목표는 API URL의 직관성 향상 및 보안 강화입니다.

--- 

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:
- [x] 변경사항 1 : RESTful한 URL 구조로 수정
        * 댓글 API (CommentController)
             댓글은 특정 게시글에 속하므로 /comment → /post/{postId}/comment 형식으로 변경
             특정 게시글에 대한 댓글이라는 의미를 명확히 하기 위해 URL을 구조화
        * 게시글 API (PostController)
              기존 URL: /post → 변경 후: /posts
              단수형 post는 특정 게시글 하나를 의미하는 데 적합하므로, 게시글 목록을 나타내는 복수형(posts)으로 변경하여 
              RESTful 원칙을 준수
- [x] 변경사항 2 : 게시글 CRUD 접근 권한 설정 - 요청을 보낸 사용자의 로그인 여부, role을 확인하여 게시글 조회, 생성, 수정, 삭제 등의 접근 가능 여부를 설정 (게시글 작성/수정/삭제는 인증된 사용자만 가능.  게시글 조회는 모든 사용자에게 허용)

---

## 📌 참고 사항 (Additional Notes)
- 게시글 수정/삭제 권한 추가 예정
     현재는 로그인한 사용자라면 모든 게시글의 수정/삭제가 가능하지만,
     수정 및 삭제 시 해당 게시글의 작성자와 수정,삭제를 요청하는 사용자가 일치하는지 확인하는 로직을 추가해야합니다.
     (관리자는 모든 게시글을 수정/삭제할 수 있도록 처리)
- 좋아요 기능 개선 예정
     현재 좋아요 기능이 사용자 구분 없이 동작하지만,
     유저별로 좋아요 상태를 관리하도록 수정해야합니다.
