### PR TITLE
feat: 게시글-작성자 매핑 및 JWT 토큰에서 이메일 제거

### DIFF
--- a/src/main/java/com/pawstime/pawstime/domain/post/controller/PostController.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/controller/PostController.java
@@ -17,6 +17,7 @@ import com.pawstime.pawstime.global.exception.InvalidException;
 import com.pawstime.pawstime.global.exception.NotFoundException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 
 import java.util.ArrayList;
@@ -51,8 +52,9 @@ public class PostController {
   @PostMapping
   @ResponseStatus(HttpStatus.CREATED)
   public ResponseEntity<ApiResponse<Long>> createPost(
-      @RequestBody CreatePostReqDto req) {
-    Long postId = postFacade.createPost(req);
+      @RequestBody CreatePostReqDto req,
+      HttpServletRequest request) {
+    Long postId = postFacade.createPost(req, request);
     return ApiResponse.generateResp(Status.CREATE, "게시글 생성이 완료되었습니다. ", postId);
   }
 

--- a/src/main/java/com/pawstime/pawstime/domain/post/dto/req/CreatePostReqDto.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/dto/req/CreatePostReqDto.java
@@ -2,6 +2,7 @@ package com.pawstime.pawstime.domain.post.dto.req;
 
 import com.pawstime.pawstime.domain.board.entity.Board;
 import com.pawstime.pawstime.domain.post.entity.Post;
+import com.pawstime.pawstime.domain.user.entity.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -17,11 +18,12 @@ public record CreatePostReqDto(
         Long boardId,           // 게시판 ID
         int likesCount          // 좋아요 수
 ) {
-    public Post toEntity(Board board) {
+    public Post toEntity(Board board, User user) {
         return Post.builder()
                 .title(this.title)
                 .content(this.content)
                 .board(board)
+                .user(user)
                 .likesCount(likesCount)  // likesCount 설정
                 .views(0)  // 기본 조회수 설정
                 .build();

--- a/src/main/java/com/pawstime/pawstime/domain/post/entity/Post.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/entity/Post.java
@@ -3,6 +3,7 @@ package com.pawstime.pawstime.domain.post.entity;
 import com.pawstime.pawstime.domain.board.entity.Board;
 import com.pawstime.pawstime.domain.image.entity.Image;
 import com.pawstime.pawstime.domain.like.entity.Like;
+import com.pawstime.pawstime.domain.user.entity.User;
 import com.pawstime.pawstime.global.entity.BaseEntity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -47,6 +48,10 @@ public class Post extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "board_id", nullable = false)
     private Board board; // Board 엔티티와 관계 설정
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 
     // 좋아요 관계 추가 (Post와 Like의 1:N 관계 설정)
     @OneToMany(mappedBy = "post", fetch = FetchType.LAZY)

--- a/src/main/java/com/pawstime/pawstime/domain/user/entity/User.java
+++ b/src/main/java/com/pawstime/pawstime/domain/user/entity/User.java
@@ -1,5 +1,6 @@
 package com.pawstime.pawstime.domain.user.entity;
 
+import com.pawstime.pawstime.domain.post.entity.Post;
 import com.pawstime.pawstime.domain.user.enums.Role;
 import com.pawstime.pawstime.global.entity.BaseEntity;
 import jakarta.persistence.Column;
@@ -9,7 +10,9 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -36,4 +39,7 @@ public class User extends BaseEntity {
 
   @Enumerated(value = EnumType.STRING)
   private Role role;
+
+  @OneToMany(mappedBy = "user")
+  private List<Post> posts;
 }

--- a/src/main/java/com/pawstime/pawstime/domain/user/entity/repository/UserRepository.java
+++ b/src/main/java/com/pawstime/pawstime/domain/user/entity/repository/UserRepository.java
@@ -2,8 +2,13 @@ package com.pawstime.pawstime.domain.user.entity.repository;
 
 import com.pawstime.pawstime.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
   User findUserByEmail(String email);
+
+  @Query("SELECT u FROM User u WHERE u.userId = :userId AND u.isDelete = false")
+  User findUserByUserIdQuery(@Param("userId") Long userId);
 }

--- a/src/main/java/com/pawstime/pawstime/domain/user/facade/UserFacade.java
+++ b/src/main/java/com/pawstime/pawstime/domain/user/facade/UserFacade.java
@@ -11,6 +11,7 @@ import com.pawstime.pawstime.global.exception.UnauthorizedException;
 import com.pawstime.pawstime.global.jwt.util.JwtUtil;
 import com.pawstime.pawstime.web.api.user.dto.req.LoginUserReqDto;
 import com.pawstime.pawstime.web.api.user.dto.req.UserCreateReqDto;
+import com.pawstime.pawstime.web.api.user.dto.resp.GetUserRespDto;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.http.HttpServletRequest;
 import java.time.LocalDateTime;
@@ -90,5 +91,13 @@ public class UserFacade {
 
     tokenBlacklistService.createTokenBlacklist(token, expTime);
     request.getSession().removeAttribute("cart");
+  }
+
+  public GetUserRespDto getUserFromUserId(Long userId) {
+    User user = readUserService.findUserByUserIdQuery(userId);
+    if (user == null) {
+      throw new NotFoundException("존재하지 않는 사용자입니다.");
+    }
+    return GetUserRespDto.from(user);
   }
 }

--- a/src/main/java/com/pawstime/pawstime/domain/user/service/read/ReadUserService.java
+++ b/src/main/java/com/pawstime/pawstime/domain/user/service/read/ReadUserService.java
@@ -14,4 +14,8 @@ public class ReadUserService {
   public User findUserByEmail(String email) {
     return userRepository.findUserByEmail(email);
   }
+
+  public User findUserByUserIdQuery(Long userId) {
+    return userRepository.findUserByUserIdQuery(userId);
+  }
 }

--- a/src/main/java/com/pawstime/pawstime/global/jwt/filter/JwtFilter.java
+++ b/src/main/java/com/pawstime/pawstime/global/jwt/filter/JwtFilter.java
@@ -29,9 +29,11 @@ public class JwtFilter extends OncePerRequestFilter {
       String token = authorization.substring(7);
 
       if (jwtUtil.validateToken(token)) {
-        String userId = jwtUtil.getUserId(token);
+        // String userId = jwtUtil.getUserId(token);
+        Long userId = jwtUtil.getUserId(token);
 
-        UserDetails userDetails = customUserDetailsService.loadUserByUsername(userId);
+        // UserDetails userDetails = customUserDetailsService.loadUserByUsername(userId);
+        UserDetails userDetails = customUserDetailsService.loadUserByUserId(userId);
 
         if (userDetails != null) {
           UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken = new UsernamePasswordAuthenticationToken(

--- a/src/main/java/com/pawstime/pawstime/global/jwt/util/JwtUtil.java
+++ b/src/main/java/com/pawstime/pawstime/global/jwt/util/JwtUtil.java
@@ -9,6 +9,7 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
 import java.security.Key;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
@@ -40,7 +41,8 @@ public class JwtUtil {
   private String createToken(CustomUserInfoDto user, long expireTime) {
     Claims claims = Jwts.claims();
     claims.put("userId", user.userId());
-    claims.put("email", user.email());
+    // claims.put("email", user.email());
+    // 보안을 위해 토큰에서 email을 제거
     claims.put("role", user.role());
 
     ZonedDateTime now = ZonedDateTime.now();
@@ -55,8 +57,13 @@ public class JwtUtil {
         .compact();
   }
 
-  public String getUserId(String token) {
-    return parseClaims(token).get("email", String.class);
+//  public String getUserId(String token) {
+//    return parseClaims(token).get("email", String.class);
+//  }
+//  userId를 email로 찾는 방법 대신 userid로 보내주기
+
+  public Long getUserId(String token) {
+    return parseClaims(token).get("userId", Long.class);
   }
 
   public boolean validateToken(String token) {
@@ -82,4 +89,21 @@ public class JwtUtil {
       return e.getClaims();
     }
   }
+
+  // 헤더에 담긴 토큰을 이용해서 로그인한 사용자의 userId를 가져옴
+  public Long getUserIdFromToken(HttpServletRequest request) {
+    String authorization = request.getHeader("Authorization");
+    String token = null;
+
+    if (authorization != null && authorization.startsWith("Bearer ")) {
+      token = authorization.substring(7);
+    }
+
+    if (token != null && validateToken(token)) {
+      return getUserId(token);
+    }
+
+    return null;
+  }
+
 }

--- a/src/main/java/com/pawstime/pawstime/global/security/user/service/CustomUserDetailsService.java
+++ b/src/main/java/com/pawstime/pawstime/global/security/user/service/CustomUserDetailsService.java
@@ -3,6 +3,7 @@ package com.pawstime.pawstime.global.security.user.service;
 import com.pawstime.pawstime.domain.user.entity.User;
 import com.pawstime.pawstime.domain.user.entity.repository.UserRepository;
 import com.pawstime.pawstime.domain.user.service.dto.CustomUserInfoDto;
+import com.pawstime.pawstime.global.exception.NotFoundException;
 import com.pawstime.pawstime.global.security.user.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -20,7 +21,16 @@ public class CustomUserDetailsService implements UserDetailsService {
 
   @Override
   public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-    User user = userRepository.findUserByEmail(email);
+//    User user = userRepository.findUserByEmail(email);
+//    CustomUserInfoDto customUserInfoDto = CustomUserInfoDto.of(user);
+//    return new CustomUserDetails(customUserInfoDto);
+
+    throw new UnsupportedOperationException("이 서비스는 userId 기반으로 동작합니다.");
+  }
+  // 토큰에 들어있는 이메일을 기반으로 user를 찾는 방식에서 userid를 기반으로 찾는 방식으로 바꿈
+
+  public UserDetails loadUserByUserId(Long userId) throws UsernameNotFoundException {
+    User user = userRepository.findUserByUserIdQuery(userId);
     CustomUserInfoDto customUserInfoDto = CustomUserInfoDto.of(user);
     return new CustomUserDetails(customUserInfoDto);
   }

--- a/src/main/java/com/pawstime/pawstime/web/api/user/UserController.java
+++ b/src/main/java/com/pawstime/pawstime/web/api/user/UserController.java
@@ -1,11 +1,13 @@
 package com.pawstime.pawstime.web.api.user;
 
+import com.pawstime.pawstime.domain.user.entity.User;
 import com.pawstime.pawstime.domain.user.facade.UserFacade;
 import com.pawstime.pawstime.global.common.ApiResponse;
 import com.pawstime.pawstime.global.enums.Status;
 import com.pawstime.pawstime.global.exception.CustomException;
 import com.pawstime.pawstime.web.api.user.dto.req.LoginUserReqDto;
 import com.pawstime.pawstime.web.api.user.dto.req.UserCreateReqDto;
+import com.pawstime.pawstime.web.api.user.dto.resp.GetUserRespDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -14,6 +16,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -54,5 +58,12 @@ public class UserController {
       userFacade.logout(authentication, request);
 
       return ApiResponse.generateResp(Status.SUCCESS, "로그아웃 되었습니다.", null);
+  }
+
+  @Operation(summary = "userId를 통해 유저 정보 조회")
+  @GetMapping("/{userId}")
+  public ResponseEntity<ApiResponse<GetUserRespDto>> getUserFromUserId(@PathVariable Long userId) {
+
+    return ApiResponse.generateResp(Status.SUCCESS, null, userFacade.getUserFromUserId(userId));
   }
 }

--- a/src/main/java/com/pawstime/pawstime/web/api/user/dto/resp/GetUserRespDto.java
+++ b/src/main/java/com/pawstime/pawstime/web/api/user/dto/resp/GetUserRespDto.java
@@ -1,0 +1,21 @@
+package com.pawstime.pawstime.web.api.user.dto.resp;
+
+import com.pawstime.pawstime.domain.user.entity.User;
+import com.pawstime.pawstime.domain.user.enums.Role;
+import lombok.Builder;
+
+@Builder
+public record GetUserRespDto(
+    Long userId,
+    String nick,
+    Role role
+) {
+
+  public static GetUserRespDto from(User user) {
+    return GetUserRespDto.builder()
+        .userId(user.getUserId())
+        .nick(user.getNick())
+        .role(user.getRole())
+        .build();
+  }
+}


### PR DESCRIPTION
## 📝 설명 (Description)
이번 PR은 JWT 토큰에서 이메일을 제거하고, userId와 role만 포함하도록 수정하며, 게시글과 작성자를 매핑하는 기능을 추가하는 작업입니다. 이를 통해 보안성을 강화하고, 성능을 개선하며, 게시글 작성자 정보를 명확하게 연결할 수 있습니다.

--- 

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:
- [x] 변경사항 1 : JWT 토큰에서 이메일 제거 - 기존에 포함된 이메일을 제외하고 userId와 role만 포함하도록 수정하였습니다.(이메일은 민감한 정보로, 탈취 당할 경우 보안에 위험을 초래할 수 있습니다. 반면 userId와 role은 비교적 민감하지 않으며, 이를 기반으로 사용자를 식별하고 권한을 확인하는 데 충분하므로 이메일을 제외하여 보안을 강화했습니다.)
- [x] 변경사항 2 : 게시글에 작성자 정보 추가 - Post 엔티티에 user 필드를 추가하여 게시글 작성자를 매핑하였습니다. 이제 게시글을 작성하면 해당 게시글이 누가 쓴 글인지 구분이 가능합니다.
- [x] 변경사항 3 : User 엔티티 수정 - User 엔티티에 posts 필드를 추가하여 추후에 사용자가 작성한 게시글만을 조회할 수 있는 기능을 쉽게 구현할 수 있도록 변경하였습니다.
- [x] 변경사항 4 : User 정보 조회 기능 추가 - userId를 기반으로 사용자의 정보(userid,nick,role)를 조회하는 기능을 추가하였습니다. 게시글 조회시 게시글에 들어있는 userid를 이용하여 닉네임을 조회할 수 있습니다.

---

## 📌 참고 사항 (Additional Notes)

