### PR TITLE
feat: userid-post 매핑 및 JWT 블랙리스트 처리 추가

### DIFF
--- a/src/main/java/com/pawstime/pawstime/domain/post/controller/PostController.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/controller/PostController.java
@@ -79,9 +79,10 @@ public class PostController {
   @PutMapping("/{postId}")
   public ResponseEntity<ApiResponse<Void>> updatePost(
       @PathVariable Long postId,
-      @RequestBody UpdatePostReqDto req
+      @RequestBody UpdatePostReqDto req,
+      HttpServletRequest httpServletRequest
   ) {
-    postFacade.updatePost(postId, req);
+    postFacade.updatePost(postId, req, httpServletRequest);
     return ApiResponse.generateResp(Status.UPDATE, "게시글 수정이 완료되었습니다.", null);
   }
 
@@ -90,16 +91,17 @@ public class PostController {
   public ResponseEntity<ApiResponse<Void>> updatePostImages(
       @PathVariable Long postId,
       @RequestParam(value = "deletedImageIds", required = false) List<Long> deletedImageIds,
-      @RequestPart(value = "newImages", required = false) List<MultipartFile> newImages) {
+      @RequestPart(value = "newImages", required = false) List<MultipartFile> newImages,
+      HttpServletRequest httpServletRequest) {
 
-    postFacade.updatePostImages(postId, deletedImageIds, newImages);
+    postFacade.updatePostImages(postId, deletedImageIds, newImages, httpServletRequest);
     return ApiResponse.generateResp(Status.UPDATE, "게시글 이미지가 수정되었습니다.", null);
   }
 
   @Operation(summary = "게시글 삭제", description = "게시글을 삭제할 수 있습니다.")
   @DeleteMapping("/{postId}")
-  public ResponseEntity<ApiResponse<Void>> deletePost(@PathVariable Long postId) {
-      postFacade.deletePost(postId);
+  public ResponseEntity<ApiResponse<Void>> deletePost(@PathVariable Long postId, HttpServletRequest httpServletRequest) {
+      postFacade.deletePost(postId, httpServletRequest);
     return ApiResponse.generateResp(Status.DELETE, "게시글 삭제가 완료되었습니다.", null);
   }
 

--- a/src/main/java/com/pawstime/pawstime/domain/post/dto/resp/GetDetailPostRespDto.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/dto/resp/GetDetailPostRespDto.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 public record GetDetailPostRespDto(
         Long boardId,
         Long postId,
+        Long userId,
         String title,
         String content,
         LocalDateTime createdAt,
@@ -24,6 +25,7 @@ public record GetDetailPostRespDto(
         return GetDetailPostRespDto.builder()
                 .boardId(post.getBoard().getBoardId())
                 .postId(post.getPostId())
+                .userId(post.getUser().getUserId())
                 .title(post.getTitle())
                 .content(post.getContent())
                 .createdAt(post.getCreatedAt())

--- a/src/main/java/com/pawstime/pawstime/domain/post/dto/resp/GetListPostRespDto.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/dto/resp/GetListPostRespDto.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 @Builder
 public record GetListPostRespDto(
         Long id,                 // 게시글 ID
+        Long userId,
         String title,            // 게시글 제목
         String contentPreview,   // 내용 미리보기
         LocalDateTime createdAt, // 작성일
@@ -19,6 +20,7 @@ public record GetListPostRespDto(
     public static GetListPostRespDto from(Post post) {
         return GetListPostRespDto.builder()
                 .id(post.getPostId())                        // 게시글 ID
+                .userId(post.getUser().getUserId())
                 .title(post.getTitle())                      // 게시글 제목
                 .contentPreview(post.getContent().length() > 100
                         ? post.getContent().substring(0, 100) + "..." // 내용 미리보기

--- a/src/main/java/com/pawstime/pawstime/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/pawstime/pawstime/global/config/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.pawstime.pawstime.global.config.security;
 
+import com.pawstime.pawstime.domain.tokenBlacklist.service.TokenBlacklistService;
 import com.pawstime.pawstime.global.jwt.filter.JwtFilter;
 import com.pawstime.pawstime.global.jwt.util.JwtUtil;
 import com.pawstime.pawstime.global.security.handler.CustomAccessDeniedHandler;
@@ -24,6 +25,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
   private final CustomUserDetailsService customUserDetailsService;
+  private final TokenBlacklistService tokenBlacklistService;
   private final JwtUtil jwtUtil;
   private final CustomAccessDeniedHandler accessDeniedHandler;
   private final CustomAuthenticationEntryPoint authenticationEntryPoint;
@@ -62,7 +64,7 @@ public class SecurityConfig {
         .sessionManagement(c -> c.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .formLogin(AbstractHttpConfigurer::disable)
         .httpBasic(AbstractHttpConfigurer::disable)
-        .addFilterBefore(new JwtFilter(customUserDetailsService, jwtUtil), UsernamePasswordAuthenticationFilter.class)
+        .addFilterBefore(new JwtFilter(customUserDetailsService, tokenBlacklistService, jwtUtil), UsernamePasswordAuthenticationFilter.class)
         .exceptionHandling(c -> c.authenticationEntryPoint((authenticationEntryPoint))
             .accessDeniedHandler(accessDeniedHandler))
         .authorizeHttpRequests(c -> c
@@ -84,8 +86,8 @@ public class SecurityConfig {
             .requestMatchers(HttpMethod.POST, "/posts/{postId}/comments").hasAnyRole("ADMIN", "USER")
             .requestMatchers(HttpMethod.GET, "/posts/{postId}/comments").permitAll()
 
-            //.anyRequest().authenticated())  // 그 외 요청은 로그인된 사용자만 접근 가능
-            .anyRequest().permitAll())   // 그 외 요청 모두 접근 가능 (로그인을 하지 않아도 모든 요청을 허용 => 보안을 위해 하지 않는 것이 좋다)
+            .anyRequest().authenticated())  // 그 외 요청은 로그인된 사용자만 접근 가능
+            //.anyRequest().permitAll())   // 그 외 요청 모두 접근 가능 (로그인을 하지 않아도 모든 요청을 허용 => 보안을 위해 하지 않는 것이 좋다)
         .build();
   }
 }

--- a/src/main/java/com/pawstime/pawstime/global/jwt/filter/JwtFilter.java
+++ b/src/main/java/com/pawstime/pawstime/global/jwt/filter/JwtFilter.java
@@ -1,5 +1,7 @@
 package com.pawstime.pawstime.global.jwt.filter;
 
+import com.pawstime.pawstime.domain.tokenBlacklist.service.TokenBlacklistService;
+import com.pawstime.pawstime.global.exception.UnauthorizedException;
 import com.pawstime.pawstime.global.jwt.util.JwtUtil;
 import com.pawstime.pawstime.global.security.user.service.CustomUserDetailsService;
 import jakarta.servlet.FilterChain;
@@ -17,6 +19,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 public class JwtFilter extends OncePerRequestFilter {
 
   private final CustomUserDetailsService customUserDetailsService;
+  private final TokenBlacklistService tokenBlacklistService;
   private final JwtUtil jwtUtil;
 
   @Override
@@ -27,6 +30,11 @@ public class JwtFilter extends OncePerRequestFilter {
 
     if (authorization != null && authorization.startsWith("Bearer ")) {
       String token = authorization.substring(7);
+
+      // 토큰이 블랙리스트에 들어있는지 확인
+      if (tokenBlacklistService.isBlacklisted(token)) {
+        throw new UnauthorizedException("로그아웃 처리된 토큰입니다. 다시 로그인해주세요");
+      }
 
       if (jwtUtil.validateToken(token)) {
         // String userId = jwtUtil.getUserId(token);

--- a/src/main/java/com/pawstime/pawstime/global/jwt/util/JwtUtil.java
+++ b/src/main/java/com/pawstime/pawstime/global/jwt/util/JwtUtil.java
@@ -106,4 +106,19 @@ public class JwtUtil {
     return null;
   }
 
+  // 헤더에 담긴 토큰을 이용해서 로그인한 사용자의 role을 가져옴
+  public String getUserRoleFromToken(HttpServletRequest request) {
+    String authorization = request.getHeader("Authorization");
+    String token = null;
+
+    if (authorization != null && authorization.startsWith("Bearer ")) {
+      token = authorization.substring(7);
+    }
+
+    if (token != null && validateToken(token)) {
+      return parseClaims(token).get("role", String.class);
+    }
+    return null;
+  }
+
 }


### PR DESCRIPTION
## 📝 설명 (Description)
게시글과 사용자 ID 간 매핑을 개선하고, JWT 블랙리스트 기능을 추가하여 보안성을 강화하였습니다.
또한, 게시글 수정 및 삭제 시 권한 검증을 추가하여 보다 안전한 운영이 가능하도록 하였습니다.

--- 

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:
- [x] 변경사항 1 : 게시글 조회 시 사용자 ID 포함 - 게시글 목록 조회, 게시글 상세 조회 시 userId도 포함하도록 dto를 수정하였습니다.
- [x] 변경사항 2 : JWT 블랙리스트 검증 추가 - 헤더에 포함된 토큰이 블랙리스트 테이블에 존재하는지 확인하는 로직을 `JwtFilter`에 추가하였습니다.  
- [x] 변경사항 3 : 게시글 수정·삭제 권한 검증 추가 - 게시글 수정 및 삭제 시 작성자의 `userId`와 현재 로그인된 `userId`가 동일한지 확인하는 검증을 추가하였습니다. (관리자는 모든 게시글을 수정 및 삭제할 수 있도록 처리하였습니다.)

---

## 📌 참고 사항 (Additional Notes)

