### PR TITLE
feat: userId-comment 매핑 및 무결성 검증 로직 추가

### DIFF
--- a/src/main/java/com/pawstime/pawstime/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/pawstime/pawstime/domain/comment/controller/CommentController.java
@@ -4,13 +4,12 @@ import com.pawstime.pawstime.domain.comment.dto.req.CreateCommentReqDto;
 import com.pawstime.pawstime.domain.comment.dto.req.UpdateCommentReqDto;
 import com.pawstime.pawstime.domain.comment.dto.resp.CreateCommentRespDto;
 import com.pawstime.pawstime.domain.comment.dto.resp.GetCommentRespDto;
-import com.pawstime.pawstime.domain.comment.entity.Comment;
 import com.pawstime.pawstime.domain.comment.facade.CommentFacade;
 import com.pawstime.pawstime.global.common.ApiResponse;
 import com.pawstime.pawstime.global.enums.Status;
-import com.pawstime.pawstime.global.exception.CustomException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,7 +20,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -38,24 +36,13 @@ public class CommentController {
   @Operation(summary = "댓글 생성", description = "특정 게시글에 댓글을 생성하는 기능입니다.")
   @PostMapping("/posts/{postId}/comments")
   public ResponseEntity<ApiResponse<CreateCommentRespDto>> createComment(
-          @PathVariable Long postId, @RequestBody CreateCommentReqDto req) {
-    try {
+          @PathVariable Long postId,
+          @RequestBody CreateCommentReqDto req,
+          HttpServletRequest httpServletRequest) {
       // 댓글 생성 후 포맷된 응답 DTO 반환
-      CreateCommentRespDto responseDto = commentFacade.createComment(postId, req);
+      CreateCommentRespDto responseDto = commentFacade.createComment(postId, req, httpServletRequest);
 
       return ApiResponse.generateResp(Status.CREATE, "댓글 생성이 완료되었습니다.", responseDto);
-
-    } catch (CustomException e) {
-      Status status = Status.valueOf(e.getClass()
-              .getSimpleName()
-              .replace("Exception", "")
-              .toUpperCase());
-      return ApiResponse.generateResp(status, e.getMessage(), null);
-
-    } catch (Exception e) {
-      return ApiResponse.generateResp(
-              Status.ERROR, "댓글 생성 중 오류가 발생하였습니다 : " + e.getMessage(), null);
-    }
   }
 
 
@@ -67,21 +54,8 @@ public class CommentController {
       @RequestParam(defaultValue = "createdAt") String sortBy,
       @RequestParam(defaultValue = "DESC") String direction
   ) {
-    try {
       return ApiResponse.generateResp(Status.SUCCESS, null,
           commentFacade.getCommentAll(pageNo, pageSize, sortBy, direction).getContent());
-
-    } catch (CustomException e) {
-      Status status = Status.valueOf(e.getClass()
-          .getSimpleName()
-          .replace("Exception", "")
-          .toUpperCase());
-      return ApiResponse.generateResp(status, e.getMessage(), null);
-
-    } catch (Exception e) {
-      return ApiResponse.generateResp(
-          Status.ERROR, "전체 댓글 조회 중 오류가 발생하였습니다 : " + e.getMessage(), null);
-    }
   }
 
   @Operation(summary = "특정 게시글 댓글 조회", description = "선택한 게시글에 달린 댓글 목록을 조회합니다.")
@@ -93,66 +67,28 @@ public class CommentController {
       @RequestParam(defaultValue = "createdAt") String sortBy,
       @RequestParam(defaultValue = "DESC") String direction
   ) {
-    try {
       return ApiResponse.generateResp(Status.SUCCESS, null,
           commentFacade.getCommentByPost(postId, pageNo, pageSize, sortBy, direction).getContent());
-
-    } catch (CustomException e) {
-      Status status = Status.valueOf(e.getClass()
-          .getSimpleName()
-          .replace("Exception", "")
-          .toUpperCase());
-      return ApiResponse.generateResp(status, e.getMessage(), null);
-
-    } catch (Exception e) {
-      return ApiResponse.generateResp(
-          Status.ERROR, "게시글 댓글 조회 중 오류가 발생하였습니다 : " + e.getMessage(), null);
-    }
   }
 
   @Operation(summary = "댓글 삭제", description = "선택한 댓글을 삭제합니다.")
   @DeleteMapping("/posts/{postId}/comments/{commentId}")
   public ResponseEntity<ApiResponse<Void>> deleteComment(
-      @PathVariable Long postId, @PathVariable Long commentId
+      @PathVariable Long postId, @PathVariable Long commentId, HttpServletRequest httpServletRequest
   ) {
-    try {
-
-      commentFacade.deleteComment(commentId);
+      commentFacade.deleteComment(postId, commentId, httpServletRequest);
 
       return ApiResponse.generateResp(Status.DELETE, "댓글이 삭제되었습니다.", null);
-
-    } catch (CustomException e) {
-      Status status = Status.valueOf(e.getClass()
-          .getSimpleName()
-          .replace("Exception", "")
-          .toUpperCase());
-      return ApiResponse.generateResp(status, e.getMessage(), null);
-
-    } catch (Exception e) {
-      return ApiResponse.generateResp(
-          Status.ERROR, "댓글 삭제 중 오류가 발생하였습니다 : " + e.getMessage(), null);
-    }
   }
 
   @Operation(summary = "댓글 수정", description = "선택한 댓글을 수정합니다.")
   @PutMapping("/posts/{postId}/comments/{commentId}")
   public ResponseEntity<ApiResponse<Void>> updateComment(
-      @PathVariable Long postId, @PathVariable Long commentId, @RequestBody UpdateCommentReqDto req
+      @PathVariable Long postId, @PathVariable Long commentId, @RequestBody UpdateCommentReqDto req,
+      HttpServletRequest httpServletRequest
   ){
-   try{
-     commentFacade.updateComment(commentId, req);
+     commentFacade.updateComment(postId, commentId, req, httpServletRequest);
      return ApiResponse.generateResp(
              Status.UPDATE, "댓글 수정이 완료되었습니다.", null);
-   }
-   catch (CustomException e){
-     Status status = Status.valueOf(e.getClass()
-             .getSimpleName()
-             .replace("Exception", "")
-             .toUpperCase());
-     return ApiResponse.generateResp(status, e.getMessage(), null);
-   } catch (Exception e) {
-     return ApiResponse.generateResp(
-             Status.ERROR, "댓글 수정 중 오류가 발생했습니다. : " + e.getMessage(), null);
-   }
   }
 }

--- a/src/main/java/com/pawstime/pawstime/domain/comment/dto/req/CreateCommentReqDto.java
+++ b/src/main/java/com/pawstime/pawstime/domain/comment/dto/req/CreateCommentReqDto.java
@@ -2,6 +2,7 @@ package com.pawstime.pawstime.domain.comment.dto.req;
 
 import com.pawstime.pawstime.domain.comment.entity.Comment;
 import com.pawstime.pawstime.domain.post.entity.Post;
+import com.pawstime.pawstime.domain.user.entity.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record CreateCommentReqDto(
@@ -9,11 +10,12 @@ public record CreateCommentReqDto(
     String content
 ) {
 
-  public Comment of(Post post) {
+  public Comment of(Post post, User user) {
 
     return Comment.builder()
         .post(post)
         .content(this.content)
+        .user(user)
         .build();
   }
 }

--- a/src/main/java/com/pawstime/pawstime/domain/comment/dto/resp/GetCommentRespDto.java
+++ b/src/main/java/com/pawstime/pawstime/domain/comment/dto/resp/GetCommentRespDto.java
@@ -9,6 +9,7 @@ public record GetCommentRespDto(
     Long commentId,
     String content,
     Long postId,
+    Long userId,
     LocalDateTime createAt,
     LocalDateTime updateAt
 ) {
@@ -18,6 +19,7 @@ public record GetCommentRespDto(
         .commentId(comment.getCommentId())
         .content(comment.getContent())
         .postId(comment.getPost().getPostId())
+        .userId(comment.getUser().getUserId())
         .createAt(comment.getCreatedAt())
         .updateAt(comment.getUpdatedAt())
         .build();

--- a/src/main/java/com/pawstime/pawstime/domain/comment/entity/Comment.java
+++ b/src/main/java/com/pawstime/pawstime/domain/comment/entity/Comment.java
@@ -1,6 +1,7 @@
 package com.pawstime.pawstime.domain.comment.entity;
 
 import com.pawstime.pawstime.domain.post.entity.Post;
+import com.pawstime.pawstime.domain.user.entity.User;
 import com.pawstime.pawstime.global.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -34,8 +35,12 @@ public class Comment extends BaseEntity {
   private String content;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "post_id")
+  @JoinColumn(name = "post_id", nullable = false)
   private Post post;
+
+  @ManyToOne
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
 
   public void updateComment(String content) {
     this.content = content;

--- a/src/main/java/com/pawstime/pawstime/domain/comment/facade/CommentFacade.java
+++ b/src/main/java/com/pawstime/pawstime/domain/comment/facade/CommentFacade.java
@@ -9,8 +9,14 @@ import com.pawstime.pawstime.domain.comment.entity.repository.CommentRepository;
 import com.pawstime.pawstime.domain.comment.service.CreateCommentService;
 import com.pawstime.pawstime.domain.comment.service.ReadCommentService;
 import com.pawstime.pawstime.domain.post.entity.Post;
+import com.pawstime.pawstime.domain.user.entity.User;
+import com.pawstime.pawstime.domain.user.service.read.ReadUserService;
+import com.pawstime.pawstime.global.exception.ForbiddenException;
 import com.pawstime.pawstime.global.exception.InvalidException;
 import com.pawstime.pawstime.global.exception.NotFoundException;
+import com.pawstime.pawstime.global.exception.UnauthorizedException;
+import com.pawstime.pawstime.global.jwt.util.JwtUtil;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -28,8 +34,18 @@ public class CommentFacade {
 
   private final ReadCommentService readCommentService;
   private final CreateCommentService createCommentService;
+  private final JwtUtil jwtUtil;
+  private final ReadUserService readUserService;
 
-  public CreateCommentRespDto createComment(Long postId, CreateCommentReqDto req) {
+  public CreateCommentRespDto createComment(Long postId, CreateCommentReqDto req, HttpServletRequest httpServletRequest) {
+    Long userId = jwtUtil.getUserIdFromToken(httpServletRequest);
+
+    if (userId == null) {
+      throw new UnauthorizedException("로그인해주세요.");
+    }
+
+    User user = readUserService.findUserByUserIdQuery(userId);
+
     Post post = readCommentService.getPostById(postId);
 
     if (post == null) {
@@ -46,8 +62,7 @@ public class CommentFacade {
     }
 
     // CreateCommentReqDto에서 Comment 객체로 변환
-    Comment comment = req.of(post); // req.of(post)는 CreateCommentReqDto에서 Comment 엔티티로 변환하는 로직
-
+    Comment comment = req.of(post, user); // req.of(post)는 CreateCommentReqDto에서 Comment 엔티티로 변환하는 로직
 
     // 새로운 댓글 생성
     Comment createdComment = createCommentService.createComment(comment);
@@ -82,8 +97,14 @@ public class CommentFacade {
     return readCommentService.getCommentByPost(postId, pageable).map(GetCommentRespDto::from);
   }
 
-  public void deleteComment(Long commentId) {
+  public void deleteComment(Long postId, Long commentId, HttpServletRequest httpServletRequest) {
     Comment comment = readCommentService.findById(commentId);
+
+    if (!comment.getUser().getUserId().equals(jwtUtil.getUserIdFromToken(httpServletRequest))) {
+      if (!jwtUtil.getUserRoleFromToken(httpServletRequest).equals("ADMIN")) {
+        throw new ForbiddenException("권한이 없습니다.");
+      }
+    }
 
     if (comment == null) {
       throw new NotFoundException("존재하지 않는 댓글 ID입니다.");
@@ -93,12 +114,24 @@ public class CommentFacade {
       throw new NotFoundException("이미 삭제된 댓글입니다.");
     }
 
+    if (!comment.getPost().getPostId().equals(postId)) {
+      throw new InvalidException("잘못된 요청입니다. 해당 댓글이 지정된 게시글에 존재하지 않습니다.");
+    }
+
     comment.softDelete();
     createCommentService.createComment(comment);
   }
-  public void updateComment(Long commentId, UpdateCommentReqDto req){
+
+  public void updateComment(Long postId, Long commentId, UpdateCommentReqDto req, HttpServletRequest httpServletRequest){
     //입력받은 commentId로 해당 댓글 조회
     Comment comment = readCommentService.findById(commentId);
+
+    if (!comment.getUser().getUserId().equals(jwtUtil.getUserIdFromToken(httpServletRequest))) {
+      if (!jwtUtil.getUserRoleFromToken(httpServletRequest).equals("ADMIN")) {
+        throw new ForbiddenException("권한이 없습니다.");
+      }
+    }
+
     if (comment == null) {
       throw new NotFoundException("존재하지 않는 댓글입니다.");
     }
@@ -106,6 +139,11 @@ public class CommentFacade {
     if(comment.isDelete()){
       throw new NotFoundException("이미 삭제된 댓글입니다.");
     }
+
+    if (!comment.getPost().getPostId().equals(postId)) {
+      throw new InvalidException("잘못된 요청입니다. 해당 댓글이 지정된 게시글에 존재하지 않습니다.");
+    }
+
     //수정된 내용 반영
     comment.updateComment(req.content());
 

--- a/src/main/java/com/pawstime/pawstime/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/pawstime/pawstime/global/config/security/SecurityConfig.java
@@ -43,12 +43,12 @@ public class SecurityConfig {
 
   // 로그인 한 사용자(관리자 + 일반유저)만 접근을 허용하는 경로
   private static final String[] ADMIN_USER_ONLY = {
-    "/users/logout", "/post/{postId}/likes", "/posts/{postId}/comments/{commentId}"
+    "/users/logout", "/posts/{postId}/likes", "/posts/{postId}/comments/{commentId}"
   };
 
   // 모든 사용자에게 접근을 허용하는 경로
   private static final String[] PUBLIC_ALL = {
-    "/users", "/users/login", "/post/{postId}/thumbnail", "/post/images/random", "/info/**"
+    "/users", "/users/login", "/users/{userId}", "/posts/{postId}/thumbnail", "/posts/images/random", "/info/**"
   };
 
   @Bean
@@ -78,10 +78,10 @@ public class SecurityConfig {
             .requestMatchers(HttpMethod.PUT, "/boards/{boardId}").hasRole("ADMIN")   // 게시판 수정 => 관리자만 가능하도록 함
             .requestMatchers(HttpMethod.GET, "/boards", "/boards/{boardId}").permitAll()   // 게시판 목록조회,상세조회 => 모두 접근 가능
 
-            .requestMatchers(HttpMethod.POST, "/post", "/post/{postId}").hasAnyRole("ADMIN", "USER")  // 게시글 생성, 게시글 이미지 업로드(생성) => 관리자,일반유저만 접근 가능
-            .requestMatchers(HttpMethod.PUT, "/post/{postId}", "/post/{postId}/images").hasAnyRole("ADMIN", "USER")   // 게시글 수정, 게시글 이미지 수정 => 관리자,일반유저만 접근 가능
-            .requestMatchers(HttpMethod.DELETE, "/post/{postId}").hasAnyRole("ADMIN", "USER")   // 게시글 삭제 => 관리자,일반유저만 접근 가능
-            .requestMatchers(HttpMethod.GET, "/post", "/post/{postId}", "/post/{postId}/images").permitAll()  // 게시글 전체 목록 조회, 게시글 상세 조회, 게시글 이미지 조회 => 모두 접근 가능
+            .requestMatchers(HttpMethod.POST, "/posts", "/posts/{postId}").hasAnyRole("ADMIN", "USER")  // 게시글 생성, 게시글 이미지 업로드(생성) => 관리자,일반유저만 접근 가능
+            .requestMatchers(HttpMethod.PUT, "/posts/{postId}", "/posts/{postId}/images").hasAnyRole("ADMIN", "USER")   // 게시글 수정, 게시글 이미지 수정 => 관리자,일반유저만 접근 가능
+            .requestMatchers(HttpMethod.DELETE, "/posts/{postId}").hasAnyRole("ADMIN", "USER")   // 게시글 삭제 => 관리자,일반유저만 접근 가능
+            .requestMatchers(HttpMethod.GET, "/posts", "/posts/{postId}", "/posts/{postId}/images").permitAll()  // 게시글 전체 목록 조회, 게시글 상세 조회, 게시글 이미지 조회 => 모두 접근 가능
 
             .requestMatchers(HttpMethod.POST, "/posts/{postId}/comments").hasAnyRole("ADMIN", "USER")
             .requestMatchers(HttpMethod.GET, "/posts/{postId}/comments").permitAll()


### PR DESCRIPTION
## 📝 설명 (Description)
댓글 기능 개선을 위해 userId와 comment 매핑을 개선하고, 
댓글 수정/삭제 시 권한 및 데이터 무결성 검증 로직을 추가하였습니다.  
--- 

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:
- [x] 변경사항 1 : Comment 엔티티에 User와 ManyToOne관계를 설정하였습니다.
- [x] 변경사항 2 : 댓글 생성 시 로그인된 사용자의 userId 토큰을 통해 추출해 이를 저장하도록 수정하였습니다.
- [x] 변경사항 3 : 댓글 조회 시 userId가 포함되도록 DTO를 수정하였습니다.
- [x] 변경사항 4 : 댓글 수정/삭제 시 작성자 또는 관리자만 가능하도록 권한 검증 로직을 추가하였습니다.
- [x] 변경사항 5 : 댓글 수정/삭제 시 postId도 함께 받아와 해당 댓글이 실제로 그 게시글에 속하는지 검증하는 로직을 추가하였습니다.

---

## 📌 참고 사항 (Additional Notes)
기존에는 commentId만 받아와 수정/삭제를 수행하였으나, 
데이터 무결성을 위해 postId와 commentId를 입력받아 함께 검증하도록 변경하였습니다.

