### PR TITLE
feat:add LikesCount to Detail Post

### DIFF
--- a/src/main/java/com/pawstime/pawstime/domain/post/dto/resp/GetDetailPostRespDto.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/dto/resp/GetDetailPostRespDto.java
@@ -15,7 +15,8 @@ public record GetDetailPostRespDto(
         String content,
         LocalDateTime createdAt,
         LocalDateTime updatedAt,
-        Long commentCount // 댓글 수
+        int likeCounts,
+        Long commentCount
 
 ) {
 
@@ -30,7 +31,8 @@ public record GetDetailPostRespDto(
                 .content(post.getContent())
                 .createdAt(post.getCreatedAt())
                 .updatedAt(post.getUpdatedAt())
-                .commentCount(commentCount)  // 댓글 수 포함
+                .commentCount(commentCount)
+                .likeCounts(post.getLikesCount())
                 .build();
     }
 }

--- a/src/main/java/com/pawstime/pawstime/domain/profileImg/entity/ProfileImg.java
+++ b/src/main/java/com/pawstime/pawstime/domain/profileImg/entity/ProfileImg.java
@@ -1,0 +1,29 @@
+package com.pawstime.pawstime.domain.profileImg.entity;
+
+import com.pawstime.pawstime.domain.user.entity.User;
+import com.pawstime.pawstime.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProfileImg extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "profile_img")
+    private Long profileImgId;
+
+    @OneToOne
+    @JoinColumn(name="user_id")
+    private User user;
+
+
+
+}

--- a/src/main/java/com/pawstime/pawstime/domain/user/entity/User.java
+++ b/src/main/java/com/pawstime/pawstime/domain/user/entity/User.java
@@ -1,17 +1,11 @@
 package com.pawstime.pawstime.domain.user.entity;
 
 import com.pawstime.pawstime.domain.post.entity.Post;
+import com.pawstime.pawstime.domain.profileImg.entity.ProfileImg;
 import com.pawstime.pawstime.domain.user.enums.Role;
 import com.pawstime.pawstime.global.entity.BaseEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
+
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -42,5 +36,8 @@ public class User extends BaseEntity {
 
   @OneToMany(mappedBy = "user")
   private List<Post> posts;
+
+  @OneToOne(mappedBy = "user")
+  private ProfileImg profileImg;
 
 }


### PR DESCRIPTION
## 📝 설명 (Description)
게시글 상세 조회 API에 좋아요(Like) 갯수를 포함하는 기능을 구현했습니다.
사용자가 특정 게시글을 조회할 때, 해당 게시글이 받은 좋아요 수를 함께 확인할 수 있도록 개선하였습니다.

--- 

## 🔄 변경 사항 (Changes)

 게시글 상세 조회 API(GET /posts/{postId})에 likeCount 추가
 Service Layer 수정: 게시글 ID 기준으로 좋아요 갯수를 조회하도록 로직 추가
 Response DTO 수정: likeCount 필드 추가

---

## 📌 참고 사항 (Additional Notes)
추가적인 설명이나 주의해야 할 사항이 있다면 적어주세요.<br>
예: 의존성 추가, 환경 설정 변경 등.
