### PR TITLE
feat:create profileImg Entity

### DIFF
--- a/src/main/java/com/pawstime/pawstime/domain/profileImg/entity/ProfileImg.java
+++ b/src/main/java/com/pawstime/pawstime/domain/profileImg/entity/ProfileImg.java
@@ -24,6 +24,7 @@ public class ProfileImg extends BaseEntity {
     @JoinColumn(name="user_id")
     private User user;
 
-
+    @Column(nullable = false)
+    private String imgUrl;
 
 }


### PR DESCRIPTION
## 📝 설명 (Description)  
User 엔티티에 ProfileImg 엔티티와의 관계를 추가하였습니다.  
프로필 이미지를 별도의 엔티티로 분리하여 관리할 수 있도록 OneToOne 매핑을 설정하였습니다.  

---  

## 🔄 변경 사항 (Changes)  
이번 PR에서 수행된 변경 사항들을 정리해주세요:  
- [x] `User` 엔티티에 `ProfileImg`와의 관계 추가 (`@OneToOne` 매핑)  
- [x] `ProfileImg` 엔티티 생성 및 `User`와의 관계 설정 (`@OneToOne`)  
- [x] `ProfileImg` 엔티티에 `imgUrl` 필드 추가 (S3에 저장된 이미지 URL 저장)  

---  

## 📌 참고 사항 (Additional Notes)  
- `ProfileImg` 엔티티에서 `User`와 1:1 관계를 유지하기 위해 `@OneToOne`과 `@JoinColumn(name="user_id")`를 사용하였습니다.  
- 추후 AWS S3와 연동하여 프로필 이미지 업로드 및 관리를 진행할 예정입니다.  
