### PR TITLE
feat: 보호소 정보 엔티티 추가 및 지역별 조회 기능 구현

### DIFF
--- a/src/main/java/com/pawstime/pawstime/domain/info/controller/InfoController.java
+++ b/src/main/java/com/pawstime/pawstime/domain/info/controller/InfoController.java
@@ -2,10 +2,11 @@ package com.pawstime.pawstime.domain.info.controller;
 
 
 import com.pawstime.pawstime.domain.info.dto.resp.GetHospitalInfoRespDto;
+import com.pawstime.pawstime.domain.info.dto.resp.GetShelterInfoRespDto;
+import com.pawstime.pawstime.domain.info.dto.resp.GetShelterOperationInfoRespDto;
 import com.pawstime.pawstime.domain.info.facade.InfoFacade;
 import com.pawstime.pawstime.global.common.ApiResponse;
 import com.pawstime.pawstime.global.enums.Status;
-import com.pawstime.pawstime.global.exception.CustomException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
@@ -28,7 +29,7 @@ public class InfoController {
 
   private final InfoFacade infoFacade;
 
-  @Operation(summary = "지역별 동물병원 정보 목록 조회")
+  @Operation(summary = "지역별 동물 병원 정보 목록 조회")
   @GetMapping("/hospitals/{addNum}")
   public ResponseEntity<ApiResponse<List<GetHospitalInfoRespDto>>> getHospitalInfo(
       @RequestParam(defaultValue = "0") int pageNo,
@@ -37,19 +38,20 @@ public class InfoController {
       @RequestParam(defaultValue = "DESC") String direction,
       @PathVariable int addNum
   ) {
-    try {
       return ApiResponse.generateResp(
           Status.SUCCESS, null, infoFacade.readHospitalInfo(pageNo, pageSize, sortBy, direction, addNum).getContent());
-    } catch (CustomException e) {
-      Status status = Status.valueOf(e.getClass()
-          .getSimpleName()
-          .replace("Exception", "")
-          .toUpperCase());
-      return ApiResponse.generateResp(status, e.getMessage(), null);
+  }
 
-    } catch (Exception e) {
-      return ApiResponse.generateResp(
-          Status.ERROR, "정보 게시판 조회 중 오류가 발생하였습니다 : " + e.getMessage(), null);
-    }
+  @Operation(summary = "지역별 동물 보호소 정보 목록 조회 (필수정보 조회 기능)")
+  @GetMapping("/shelters/{addNum}")
+  public ResponseEntity<ApiResponse<List<GetShelterInfoRespDto>>> getShelterInfo(
+      @RequestParam(defaultValue = "0") int pageNo,
+      @RequestParam(defaultValue = "10") int pageSize,
+      @RequestParam(defaultValue = "name") String sortBy,
+      @RequestParam(defaultValue = "DESC") String direction,
+      @PathVariable int addNum
+  ) {
+    return ApiResponse.generateResp(
+        Status.SUCCESS, null, infoFacade.readShelterInfo(pageNo, pageSize, sortBy, direction, addNum).getContent());
   }
 }

--- a/src/main/java/com/pawstime/pawstime/domain/info/dto/resp/GetShelterInfoRespDto.java
+++ b/src/main/java/com/pawstime/pawstime/domain/info/dto/resp/GetShelterInfoRespDto.java
@@ -1,0 +1,30 @@
+package com.pawstime.pawstime.domain.info.dto.resp;
+
+import com.pawstime.pawstime.domain.info.entity.ShelterInfo;
+import lombok.Builder;
+
+@Builder
+public record GetShelterInfoRespDto(
+    Long shelterId,
+    String name,
+    String type,
+    String add1,
+    Integer addNum,
+    Double x,
+    Double y,
+    String tel
+) {
+
+  public static GetShelterInfoRespDto from(ShelterInfo info) {
+    return GetShelterInfoRespDto.builder()
+        .shelterId(info.getShelterId())
+        .name(info.getName())
+        .type(info.getType())
+        .add1(info.getAdd1())
+        .addNum(info.getAddNum())
+        .x(Double.parseDouble(info.getX()))
+        .y(Double.parseDouble(info.getY()))
+        .tel(info.getTel())
+        .build();
+  }
+}

--- a/src/main/java/com/pawstime/pawstime/domain/info/dto/resp/GetShelterOperationInfoRespDto.java
+++ b/src/main/java/com/pawstime/pawstime/domain/info/dto/resp/GetShelterOperationInfoRespDto.java
@@ -1,0 +1,53 @@
+package com.pawstime.pawstime.domain.info.dto.resp;
+
+import com.pawstime.pawstime.domain.info.entity.ShelterOperationInfo;
+import lombok.Builder;
+
+@Builder
+public record GetShelterOperationInfoRespDto(
+    Long shelterOperationId,
+    String saveTrgtAnimal,
+    String add2,
+    String weekOprStime,
+    String weekOprEtime,
+    String closeDay,
+    int vetPersonCnt,
+    int specsPersonCnt,
+    String weekCellStime,
+    String weekCellEtime,
+    int medicalCnt,
+    int breedCnt,
+    int quarantineCnt,
+    int feedCnt,
+    int transCarCnt,
+    String weekendStime,
+    String weekendEtime,
+    String weekendCellStime,
+    String weekendCellEtime
+) {
+
+  public static GetShelterOperationInfoRespDto from(ShelterOperationInfo info) {
+    return GetShelterOperationInfoRespDto.builder()
+        .shelterOperationId(info.getShelterOperationId())
+        .saveTrgtAnimal(info.getSaveTrgtAnimal())
+        .add2(info.getAdd2())
+        .weekOprStime(info.getWeekOprStime())
+        .weekOprEtime(info.getWeekOprEtime())
+        .closeDay(info.getCloseDay())
+        .vetPersonCnt(info.getVetPersonCnt())
+        .specsPersonCnt(info.getSpecsPersonCnt())
+        .weekCellStime(info.getWeekCellStime())
+        .weekCellEtime(info.getWeekCellEtime())
+        .medicalCnt(info.getMedicalCnt())
+        .breedCnt(info.getBreedCnt())
+        .quarantineCnt(info.getQuarantineCnt())
+        .feedCnt(info.getFeedCnt())
+        .transCarCnt(info.getTransCarCnt())
+        .weekendStime(info.getWeekendStime())
+        .weekendEtime(info.getWeekendEtime())
+        .weekendCellStime(info.getWeekendCellStime())
+        .weekendCellEtime(info.getWeekendCellEtime())
+        .build();
+  }
+}
+

--- a/src/main/java/com/pawstime/pawstime/domain/info/entity/ShelterInfo.java
+++ b/src/main/java/com/pawstime/pawstime/domain/info/entity/ShelterInfo.java
@@ -1,0 +1,40 @@
+package com.pawstime.pawstime.domain.info.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "shelters")
+public class ShelterInfo {
+
+  @Id
+  @Column(name = "shelter_id")
+  private Long shelterId;
+
+  private String name;  // 동물 보호 센터명
+
+  private String type;  // 동물 보호 센터 유형
+
+  private String add1;  // 신주소
+
+  @Column(name = "add_num")
+  private int addNum;   // 지역 번호
+
+  private String tel;   // 전화 번호
+
+  private String x;
+
+  private String y;
+}

--- a/src/main/java/com/pawstime/pawstime/domain/info/entity/ShelterOperationInfo.java
+++ b/src/main/java/com/pawstime/pawstime/domain/info/entity/ShelterOperationInfo.java
@@ -1,0 +1,87 @@
+package com.pawstime.pawstime.domain.info.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "shelters_operation")
+public class ShelterOperationInfo {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "shelter_operation_id")
+  private Long ShelterOperationId;
+
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "shelter_id", nullable = false)
+  private ShelterInfo shelterInfo;
+
+  @Column(name = "save_trgt_animal")
+  private String saveTrgtAnimal;  // 구조 대상 동물
+
+  @Column(name = "add2")
+  private String add2;  // 구주소
+
+  @Column(name = "week_opr_stime")
+  private String weekOprStime;  // 평일 운영 시작 시각
+
+  @Column(name = "week_opr_etime")
+  private String weekOprEtime;  // 평일 운영 종료 시각
+
+  @Column(name = "close_day")
+  private String closeDay;  // 휴무일
+
+  @Column(name = "vet_person_cnt")
+  private int vetPersonCnt;  // 수의사 인원 수
+
+  @Column(name = "specs_person_cnt")
+  private int specsPersonCnt;  // 사양관리사 인원 수
+
+  @Column(name = "week_cell_stime")
+  private String weekCellStime;  // 평일 분양 시작 시각
+
+  @Column(name = "week_cell_etime")
+  private String weekCellEtime;  // 평일 분양 종료 시각
+
+  @Column(name = "medical_cnt")
+  private int medicalCnt;  // 진료실 수
+
+  @Column(name = "breed_cnt")
+  private int breedCnt;  // 사육실 수
+
+  @Column(name = "quarantine_cnt")
+  private int quarantineCnt;  // 격리실 수
+
+  @Column(name = "feed_cnt")
+  private int feedCnt;  // 사료 보관실 수
+
+  @Column(name = "trans_car_cnt")
+  private int transCarCnt;  // 구조 운반용 차량 보유 대수
+
+  @Column(name = "weekend_stime")
+  private String weekendStime;  // 주말 운영 시작 시각
+
+  @Column(name = "weekend_etime")
+  private String weekendEtime;  // 주말 운영 종료 시각
+
+  @Column(name = "weekend_cell_stime")
+  private String weekendCellStime;  // 주말 분양 시작 시각
+
+  @Column(name = "weekend_cell_etime")
+  private String weekendCellEtime;  // 주말 분양 종료 시각
+}

--- a/src/main/java/com/pawstime/pawstime/domain/info/entity/repository/ShelterInfoRepository.java
+++ b/src/main/java/com/pawstime/pawstime/domain/info/entity/repository/ShelterInfoRepository.java
@@ -1,0 +1,16 @@
+package com.pawstime.pawstime.domain.info.entity.repository;
+
+import com.pawstime.pawstime.domain.info.entity.ShelterInfo;
+import com.pawstime.pawstime.domain.info.entity.ShelterOperationInfo;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ShelterInfoRepository extends JpaRepository<ShelterInfo, Long> {
+
+  @Query("SELECT s FROM ShelterInfo s WHERE s.addNum = :addNum")
+  Page<ShelterInfo> findAllQuery(Pageable pageable, int addNum);
+}

--- a/src/main/java/com/pawstime/pawstime/domain/info/facade/InfoFacade.java
+++ b/src/main/java/com/pawstime/pawstime/domain/info/facade/InfoFacade.java
@@ -1,7 +1,13 @@
 package com.pawstime.pawstime.domain.info.facade;
 
 import com.pawstime.pawstime.domain.info.dto.resp.GetHospitalInfoRespDto;
+import com.pawstime.pawstime.domain.info.dto.resp.GetShelterInfoRespDto;
+import com.pawstime.pawstime.domain.info.dto.resp.GetShelterOperationInfoRespDto;
+import com.pawstime.pawstime.domain.info.entity.ShelterOperationInfo;
 import com.pawstime.pawstime.domain.info.service.ReadHospitalInfoService;
+import com.pawstime.pawstime.domain.info.service.ReadShelterInfoService;
+import com.pawstime.pawstime.global.exception.NotFoundException;
+import java.net.ContentHandler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -18,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class InfoFacade {
 
     private final ReadHospitalInfoService readHospitalInfoService;
+    private final ReadShelterInfoService readShelterInfoService;
 
     public Page<GetHospitalInfoRespDto> readHospitalInfo(int pageNo, int pageSize, String sortBy, String direcrion, int addNum) {
 
@@ -25,4 +32,11 @@ public class InfoFacade {
 
         return readHospitalInfoService.readAllHospital(pageable, addNum).map(GetHospitalInfoRespDto::from);
     }
+
+  public Page<GetShelterInfoRespDto> readShelterInfo(int pageNo, int pageSize, String sortBy, String direction, int addNum) {
+
+      Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by(Sort.Direction.fromString(direction), sortBy));
+
+      return readShelterInfoService.readAllShelter(pageable, addNum).map(GetShelterInfoRespDto::from);
+  }
 }

--- a/src/main/java/com/pawstime/pawstime/domain/info/service/ReadShelterInfoService.java
+++ b/src/main/java/com/pawstime/pawstime/domain/info/service/ReadShelterInfoService.java
@@ -1,0 +1,21 @@
+package com.pawstime.pawstime.domain.info.service;
+
+import com.pawstime.pawstime.domain.info.entity.ShelterInfo;
+import com.pawstime.pawstime.domain.info.entity.ShelterOperationInfo;
+import com.pawstime.pawstime.domain.info.entity.repository.ShelterInfoRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ReadShelterInfoService {
+
+  private final ShelterInfoRepository infoRepository;
+
+  public Page<ShelterInfo> readAllShelter(Pageable pageable, int addNum) {
+    return infoRepository.findAllQuery(pageable, addNum);
+  }
+}

--- a/src/main/java/com/pawstime/pawstime/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/pawstime/pawstime/global/config/security/SecurityConfig.java
@@ -12,6 +12,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -48,7 +49,8 @@ public class SecurityConfig {
 
   // 모든 사용자에게 접근을 허용하는 경로
   private static final String[] PUBLIC_ALL = {
-    "/users", "/users/login", "/users/{userId}", "/posts/{postId}/thumbnail", "/posts/images/random", "/info/**"
+    "/users", "/users/login", "/users/{userId}", "/posts/{postId}/thumbnail",
+    "/posts/images/random", "/info/**"
   };
 
   @Bean


### PR DESCRIPTION
## 📝 설명 (Description)
보호소 정보를 관리하기 위해 보호소 필수 정보 / 추가 정보 두가지로 엔티티를 분리하여 추가하고,
지역별로 보호소 목록을 조회할 수 있는 기능을 구현했습니다.
또한, 페이징 기능을 적용하여 효율적인 데이터 조회가 가능하도록 하였습니다

--- 

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:
- [x] 변경사항 1 : 보호소 필수정보 엔티티 /  추가 운영정보 엔티티  => 추가
- [x] 변경사항 2 : 보호소 필수 정보 지역별 조회 기능 구현 (페이징)

---

## 📌 참고 사항 (Additional Notes)
현재 필수 정보만 조회 가능하며, 추가 정보 엔티티는 이후 별도로 구현할 예정입니다.
