### PR TITLE
Feat:Update Profile Image

### DIFF
--- a/src/main/java/com/pawstime/pawstime/aws/s3/config/S3Config.java
+++ b/src/main/java/com/pawstime/pawstime/aws/s3/config/S3Config.java
@@ -1,4 +1,4 @@
-package com.pawstime.pawstime.global.config.aws;
+package com.pawstime.pawstime.aws.s3.config;
 
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;

--- a/src/main/java/com/pawstime/pawstime/aws/s3/service/S3Service.java
+++ b/src/main/java/com/pawstime/pawstime/aws/s3/service/S3Service.java
@@ -1,16 +1,10 @@
-package com.pawstime.pawstime.domain.post.service;
+package com.pawstime.pawstime.aws.s3.service;
+
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -18,8 +12,15 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
-import com.amazonaws.services.s3.model.ObjectMetadata;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
 import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 
 @Slf4j
 @Service

--- a/src/main/java/com/pawstime/pawstime/domain/image/service/UpdateImageService.java
+++ b/src/main/java/com/pawstime/pawstime/domain/image/service/UpdateImageService.java
@@ -1,9 +1,9 @@
 package com.pawstime.pawstime.domain.image.service;
 
+import com.pawstime.pawstime.aws.s3.service.S3Service;
 import com.pawstime.pawstime.domain.image.entity.Image;
 import com.pawstime.pawstime.domain.image.entity.repository.ImageRepository;
 import com.pawstime.pawstime.domain.post.entity.Post;
-import com.pawstime.pawstime.domain.post.service.S3Service;
 import com.pawstime.pawstime.global.exception.NotFoundException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/pawstime/pawstime/domain/post/controller/PostController.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/controller/PostController.java
@@ -1,27 +1,21 @@
 package com.pawstime.pawstime.domain.post.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pawstime.pawstime.aws.s3.service.S3Service;
 import com.pawstime.pawstime.domain.image.dto.resp.GetImageRespDto;
 import com.pawstime.pawstime.domain.like.facade.LikeFacade;
 import com.pawstime.pawstime.domain.post.dto.req.CreatePostReqDto;
 import com.pawstime.pawstime.domain.post.dto.req.UpdatePostReqDto;
 import com.pawstime.pawstime.domain.post.dto.resp.GetDetailPostRespDto;
 import com.pawstime.pawstime.domain.post.dto.resp.GetListPostRespDto;
-import com.pawstime.pawstime.domain.post.entity.Post;
 import com.pawstime.pawstime.domain.post.facade.PostFacade;
-import com.pawstime.pawstime.domain.post.service.S3Service;
 import com.pawstime.pawstime.global.common.ApiResponse;
 import com.pawstime.pawstime.global.enums.Status;
 import com.pawstime.pawstime.global.exception.CustomException;
-import com.pawstime.pawstime.global.exception.InvalidException;
-import com.pawstime.pawstime.global.exception.NotFoundException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.validation.Valid;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import lombok.RequiredArgsConstructor;
@@ -45,7 +39,6 @@ import org.springframework.web.multipart.MultipartFile;
 public class PostController {
 
   private final PostFacade postFacade;
-  private final LikeFacade likeFacade;
   private final S3Service s3Service;
 
   @Operation(summary = "게시글 생성", description = "게시글을 생성할 수 있습니다.")

--- a/src/main/java/com/pawstime/pawstime/domain/post/facade/PostFacade.java
+++ b/src/main/java/com/pawstime/pawstime/domain/post/facade/PostFacade.java
@@ -1,9 +1,9 @@
 package com.pawstime.pawstime.domain.post.facade;
 
+import com.pawstime.pawstime.aws.s3.service.S3Service;
 import com.pawstime.pawstime.domain.board.entity.Board;
 import com.pawstime.pawstime.domain.image.dto.resp.GetImageRespDto;
 import com.pawstime.pawstime.domain.image.entity.Image;
-import com.pawstime.pawstime.domain.image.entity.repository.ImageRepository;
 import com.pawstime.pawstime.domain.image.service.ReadImageService;
 import com.pawstime.pawstime.domain.image.service.UpdateImageService;
 import com.pawstime.pawstime.domain.post.dto.req.CreatePostReqDto;
@@ -16,7 +16,6 @@ import com.pawstime.pawstime.domain.post.service.CreatePostService;
 import com.pawstime.pawstime.domain.post.service.GetDetailPostService;
 import com.pawstime.pawstime.domain.post.service.GetListPostService;
 import com.pawstime.pawstime.domain.post.service.ReadPostService;
-import com.pawstime.pawstime.domain.post.service.S3Service;
 import com.pawstime.pawstime.domain.post.service.UpdatePostService;
 import com.pawstime.pawstime.domain.user.entity.User;
 import com.pawstime.pawstime.domain.user.service.read.ReadUserService;
@@ -27,7 +26,7 @@ import com.pawstime.pawstime.global.exception.NotFoundException;
 import com.pawstime.pawstime.global.exception.UnauthorizedException;
 import com.pawstime.pawstime.global.jwt.util.JwtUtil;
 import jakarta.servlet.http.HttpServletRequest;
-import java.util.ArrayList;
+
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -56,11 +55,12 @@ public class PostFacade {
     private final GetDetailPostService getDetailPostService;
     private final GetListPostService getListPostService;
     private final PostRepository postRepository;
-    private final S3Service s3Service;
+
     private final UpdateImageService updateImageService;
     private final ReadImageService readImageService;
     private final JwtUtil jwtUtil;
     private final ReadUserService readUserService;
+    private final S3Service s3Service;
 
     //게시글 생성
     public Long createPost(CreatePostReqDto req, HttpServletRequest request) {
@@ -213,7 +213,6 @@ public class PostFacade {
 
         }
     }
-
 
     public void deletePost(Long postId, HttpServletRequest httpServletRequest) {
         // 게시글 조회

--- a/src/main/java/com/pawstime/pawstime/domain/profileImg/controller/ProfileImgController.java
+++ b/src/main/java/com/pawstime/pawstime/domain/profileImg/controller/ProfileImgController.java
@@ -1,0 +1,35 @@
+package com.pawstime.pawstime.domain.profileImg.controller;
+
+import com.pawstime.pawstime.domain.profileImg.facade.ProfileImgFacade;
+import com.pawstime.pawstime.global.common.ApiResponse;
+import com.pawstime.pawstime.global.enums.Status;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@Tag(name = " ProfileImg", description = "프로필 이미지 API")
+@RestController
+@RequestMapping("/profileImg")
+@RequiredArgsConstructor
+public class ProfileImgController {
+
+    private final ProfileImgFacade profileImgFacade;
+
+    @Operation(summary = "프로필 이미지 변경", description = "프로필 이미지를 변경할 수 있습니다.")
+    @PutMapping(value = "/{userId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<Void>> updateProfileImg(
+            @PathVariable Long userId,
+            @RequestParam("file") MultipartFile file
+            ){
+        profileImgFacade.updateProfileImg(userId, file);
+        return ApiResponse.generateResp(
+                Status.UPDATE, "프로필 수정이 완료되었습니다.", null
+        );
+    }
+}

--- a/src/main/java/com/pawstime/pawstime/domain/profileImg/entity/ProfileImg.java
+++ b/src/main/java/com/pawstime/pawstime/domain/profileImg/entity/ProfileImg.java
@@ -28,4 +28,8 @@ public class ProfileImg extends BaseEntity {
     @Column(nullable = false)
     private String profileImgUrl;
 
+    public void updateProfileImgUrl(String newProfileImgUrl){
+        this.profileImgUrl = newProfileImgUrl;
+    }
+
 }

--- a/src/main/java/com/pawstime/pawstime/domain/profileImg/entity/repository/ProfileRepository.java
+++ b/src/main/java/com/pawstime/pawstime/domain/profileImg/entity/repository/ProfileRepository.java
@@ -1,6 +1,7 @@
 package com.pawstime.pawstime.domain.profileImg.entity.repository;
 
 import com.pawstime.pawstime.domain.profileImg.entity.ProfileImg;
+import com.pawstime.pawstime.domain.user.entity.User;
 import org.apache.ibatis.annotations.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -8,6 +9,8 @@ import org.springframework.data.jpa.repository.Query;
 import java.util.Optional;
 
 public interface ProfileRepository extends JpaRepository<ProfileImg, Long> {
+
     @Query("SELECT p FROM ProfileImg p WHERE p.user.userId = :userId")
-    Optional<ProfileImg> findProfileImgByUserId(@Param("userId")Long userId);
+    Optional<ProfileImg> findProfileImgByUserId(@Param("userId") Long userId);
+
 }

--- a/src/main/java/com/pawstime/pawstime/domain/profileImg/facade/ProfileImgFacade.java
+++ b/src/main/java/com/pawstime/pawstime/domain/profileImg/facade/ProfileImgFacade.java
@@ -1,0 +1,54 @@
+package com.pawstime.pawstime.domain.profileImg.facade;
+
+import com.pawstime.pawstime.aws.s3.service.S3Service;
+import com.pawstime.pawstime.domain.profileImg.entity.ProfileImg;
+import com.pawstime.pawstime.domain.profileImg.service.CreateProfileImgService;
+import com.pawstime.pawstime.domain.profileImg.service.ReadProfileImgService;
+
+import com.pawstime.pawstime.global.exception.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Collections;
+
+@Slf4j
+@Transactional
+@Component
+@RequiredArgsConstructor
+public class ProfileImgFacade {
+
+    private final ReadProfileImgService readProfileImgService;
+    private final CreateProfileImgService createProfileImgService;
+    private final S3Service s3Service;
+
+    @Value("${default.profile-img-url}")
+    private String defaultProfileImgUrl;
+
+    //1.프로필 이미지 변경
+    public void updateProfileImg(Long userId, MultipartFile file){
+        ProfileImg profileImg = readProfileImgService.findByUserId(userId)
+                .orElseThrow(() -> new NotFoundException("사용자를 찾을 수 없습니다."));
+
+        //s3에 이미지 업로드 후 url 반환
+        String newImgUrl = s3Service.uploadFile(Collections.singletonList(file)).get(0);
+
+        //기존 프로필 이미지 업데이트
+        profileImg.updateProfileImgUrl(newImgUrl);
+        createProfileImgService.save(profileImg);
+
+
+    }
+
+/*    @Transactional
+    public void deleteProfileImg(Long userId) {
+        ProfileImg profileImg = readProfileImgService.findByUserId(userId)
+                .orElseThrow(() -> new IllegalArgumentException("프로필을 찾을 수 없습니다."));
+
+        profileImg.updateProfileImgUrl(defaultProfileImgUrl); // 기본 이미지로 변경
+        createProfileImgService.save(profileImg);
+    }*/
+}

--- a/src/main/java/com/pawstime/pawstime/domain/profileImg/service/CreateProfileImgService.java
+++ b/src/main/java/com/pawstime/pawstime/domain/profileImg/service/CreateProfileImgService.java
@@ -1,0 +1,20 @@
+package com.pawstime.pawstime.domain.profileImg.service;
+
+import com.pawstime.pawstime.domain.profileImg.entity.ProfileImg;
+import com.pawstime.pawstime.domain.profileImg.entity.repository.ProfileRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CreateProfileImgService {
+
+    private final ProfileRepository profileRepository;
+
+    @Transactional
+    public ProfileImg save(ProfileImg profileImg){
+        return profileRepository.save(profileImg);
+    }
+
+}

--- a/src/main/java/com/pawstime/pawstime/domain/profileImg/service/ReadProfileImgService.java
+++ b/src/main/java/com/pawstime/pawstime/domain/profileImg/service/ReadProfileImgService.java
@@ -1,0 +1,23 @@
+package com.pawstime.pawstime.domain.profileImg.service;
+
+import com.pawstime.pawstime.domain.profileImg.entity.ProfileImg;
+import com.pawstime.pawstime.domain.profileImg.entity.repository.ProfileRepository;
+import com.pawstime.pawstime.global.exception.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReadProfileImgService {
+
+    private final ProfileRepository profileRepository;
+
+    //유저의 프로필 이미지 조회
+    public Optional<ProfileImg> findByUserId(Long userId){
+        return profileRepository.findProfileImgByUserId(userId);
+    }
+}

--- a/src/main/java/com/pawstime/pawstime/domain/user/entity/repository/UserRepository.java
+++ b/src/main/java/com/pawstime/pawstime/domain/user/entity/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package com.pawstime.pawstime.domain.user.entity.repository;
 
+import com.pawstime.pawstime.domain.profileImg.entity.ProfileImg;
 import com.pawstime.pawstime.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -11,5 +12,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
   @Query("SELECT u FROM User u WHERE u.userId = :userId AND u.isDelete = false")
   User findUserByUserIdQuery(@Param("userId") Long userId);
+
+
 
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -19,6 +19,11 @@ spring:
     expiration_time: 86400000
     secret:
       key: VlwEyVBsYt9V7zq57TejMnVUyzblYcfPQye08f7MGVA9XkHa
+  servlet:
+    multipart:
+      enabled: true
+      max-file-size: 10MB
+      max-request-size: 10MB
 
 server:
   port: 8080
@@ -28,14 +33,8 @@ aws:
     access-key-id: ${AWS_ACCESS_KEY_ID}        # GitHub Secrets로 전달
     secret-access-key: ${AWS_SECRET_ACCESS_KEY} # GitHub Secrets로 전달
     region: ${AWS_REGION}                      # GitHub Secrets로 전달
-    bucket-name: ${AWS_BUCKET_NAME}    # GitHub Secrets로 전달
+    bucket-name: ${AWS_BUCKET_NAME}            # GitHub Secrets로 전달
 
 default:
-  img-url: "/static/default-img.jpg"
-
-  spring:
-    servlet:
-      multipart:
-        enabled: true
-        max-file-size: 10MB
-        max-request-size: 10MB
+  img-url: "https://s3.ap-northeast-2.amazonaws.com/paws-time-bucket/default-img.jpg"
+  profile-img-url: "https://s3.ap-northeast-2.amazonaws.com/paws-time-bucket/profile/profile-img.jpg"


### PR DESCRIPTION
## 📝 설명 (Description)
사용자의 프로필 이미지를 변경할 수 있도록 `ProfileImgController`에 프로필 이미지 수정 API를 추가했습니다.  
이 변경을 통해 사용자는 새로운 프로필 사진을 업로드하고 기존 프로필 사진을 업데이트할 수 있습니다.

---

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:
- [x] `PUT /profileImg/{userId}` API 추가: 사용자가 프로필 이미지를 변경할 수 있도록 엔드포인트 구현
- [x] `ProfileImgFacade.updateProfileImg(userId, file)` 메서드 호출하여 비즈니스 로직 처리
- [x] `ApiResponse.generateResp(Status.UPDATE, "프로필 수정이 완료되었습니다.", null)`을 사용하여 응답 표준화

---

## 📌 참고 사항 (Additional Notes)
- 프로필 이미지 업로드 시 `MultipartFile`을 사용하며, `MediaType.MULTIPART_FORM_DATA_VALUE`을 적용했습니다.
- 추후 기존 프로필 이미지 삭제 기능이 필요할 경우 S3에서 기존 이미지 삭제 로직을 추가해야 할 수도 있습니다.
- 파일 확장자 및 크기 제한 검토가 필요합니다.
