### PR TITLE
feat: 마이페이지에서 유저의 닉네임 및 비밀번호 변경 기능 구현

### DIFF
--- a/src/main/java/com/pawstime/pawstime/domain/user/entity/User.java
+++ b/src/main/java/com/pawstime/pawstime/domain/user/entity/User.java
@@ -47,4 +47,12 @@ public class User extends BaseEntity {
     this.isDeleted = true;
   }
 
+  public void updateNick(String nick) {
+    this.nick = nick;
+  }
+
+  public void updatePassword(String password) {
+    this.password = password;
+  }
+
 }

--- a/src/main/java/com/pawstime/pawstime/domain/user/service/create/CreateUserService.java
+++ b/src/main/java/com/pawstime/pawstime/domain/user/service/create/CreateUserService.java
@@ -26,4 +26,8 @@ public class CreateUserService {
 
     profileRepository.save(profileImg);
   }
+
+  public void updateUser(User user) {
+    userRepository.save(user);
+  }
 }

--- a/src/main/java/com/pawstime/pawstime/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/pawstime/pawstime/global/config/security/SecurityConfig.java
@@ -45,7 +45,7 @@ public class SecurityConfig {
   // 로그인 한 사용자(관리자 + 일반유저)만 접근을 허용하는 경로
   private static final String[] ADMIN_USER_ONLY = {
     "/users/logout", "/posts/{postId}/likes", "/posts/{postId}/comments/{commentId}",
-    "/posts/me", "/comments/me"
+    "/posts/me", "/comments/me", "/users/me/nick", "/users/me/password"
   };
 
   // 모든 사용자에게 접근을 허용하는 경로

--- a/src/main/java/com/pawstime/pawstime/web/api/user/UserController.java
+++ b/src/main/java/com/pawstime/pawstime/web/api/user/UserController.java
@@ -6,6 +6,8 @@ import com.pawstime.pawstime.global.common.ApiResponse;
 import com.pawstime.pawstime.global.enums.Status;
 import com.pawstime.pawstime.global.exception.CustomException;
 import com.pawstime.pawstime.web.api.user.dto.req.LoginUserReqDto;
+import com.pawstime.pawstime.web.api.user.dto.req.UpdateNickReqDto;
+import com.pawstime.pawstime.web.api.user.dto.req.UpdatePasswordReqDto;
 import com.pawstime.pawstime.web.api.user.dto.req.UserCreateReqDto;
 import com.pawstime.pawstime.web.api.user.dto.resp.GetUserRespDto;
 import io.swagger.v3.oas.annotations.Operation;
@@ -13,6 +15,8 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -70,4 +74,24 @@ public class UserController {
       return ApiResponse.generateResp(Status.DELETE, "회원탈퇴가 완료되었습니다.", null);
   }
 
+  @Operation(summary = "현재 로그인한 사용자의 닉네임 변경")
+  @PutMapping("/me/nick")
+  public ResponseEntity<ApiResponse<Void>> updateNick(
+      @Valid @RequestBody UpdateNickReqDto updateNickReqDto,
+      HttpServletRequest httpServletRequest) {
+    userFacade.updateNick(updateNickReqDto, httpServletRequest);
+    return ApiResponse.generateResp(Status.UPDATE, "닉네임 수정이 완료되었습니다.", null);
+  }
+
+  @Operation(summary = "현재 로그인한 사용자의 비밀번호 변경")
+  @PutMapping("/me/password")
+  public ResponseEntity<ApiResponse<Void>> updatePassword(
+      @Valid @RequestBody UpdatePasswordReqDto updatePasswordReqDto,
+      Authentication authentication,
+      HttpServletRequest httpServletRequest
+  ) {
+    userFacade.updatePassword(updatePasswordReqDto, httpServletRequest);
+    userFacade.logout(authentication, httpServletRequest);
+    return ApiResponse.generateResp(Status.UPDATE, "비밀번호 수정이 완료되었습니다.", null);
+  }
 }

--- a/src/main/java/com/pawstime/pawstime/web/api/user/dto/req/UpdateNickReqDto.java
+++ b/src/main/java/com/pawstime/pawstime/web/api/user/dto/req/UpdateNickReqDto.java
@@ -1,0 +1,14 @@
+package com.pawstime.pawstime.web.api.user.dto.req;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UpdateNickReqDto(
+    @Schema(description = "변경할 닉네임", example = "user1")
+    @NotBlank(message = "변경할 닉네임을 입력하세요.")
+    @Size(min = 2, max = 12, message = "닉네임은 2자 이상 12자 이하만 가능합니다.")
+    String nick
+) {
+
+}

--- a/src/main/java/com/pawstime/pawstime/web/api/user/dto/req/UpdatePasswordReqDto.java
+++ b/src/main/java/com/pawstime/pawstime/web/api/user/dto/req/UpdatePasswordReqDto.java
@@ -1,0 +1,21 @@
+package com.pawstime.pawstime.web.api.user.dto.req;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record UpdatePasswordReqDto(
+    @Schema(description = "기존 비밀번호", example = "Qwer1234^^")
+    @NotBlank(message = "기존 비밀번호를 입력하세요.")
+    String currentPassword,
+
+    @Schema(description = "변경할 비밀번호", example = "Qwer12345^^")
+    @NotBlank(message = "변경할 비밀번호를 입력하세요.")
+    @Size(min = 8, max = 20, message = "새로운 비밀번호는 8자 이상 20자 이하만 가능합니다.")
+    @Pattern(regexp = "^(?=.*[A-Z])(?=.*[0-9])(?=.*[a-z])(?=.*[!@#$%^&*()-+=]).*$",
+        message = "새로운 비밀번호는 대/소문자, 숫자, 특수문자를 포함해야 합니다.")
+    String newPassword
+) {
+
+}


### PR DESCRIPTION
## 📝 설명 (Description)
로그인한 사용의 닉네임과 비밀번호를 변경할 수 있는 기능을 구현했습니다.

--- 

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:
- [x] 변경사항 1 : 로그인한 사용자의 닉네임 변경 - 토큰에서 userId 추출 후 해당 유저의 닉네임 변경
- [x] 변경사항 2 : 로그인한 사용자의 비밀번호 변경 - 보안을 위해 기존 비밀번호 확인 후 새 비밀번호 입력 및 검증
                           비밀번호 변경 후 로그아웃 처리 및 해당 토큰 블랙리스트에 저장

---

## 📌 참고 사항 (Additional Notes)
비밀번호 정규표현식 검증 기준은 길이, 대소문자, 숫자, 특수문자 등을 포함해야 합니다.
