### PR TITLE
refactor: 닉네임 중복 확인 기능 추가

### DIFF
--- a/src/main/java/com/pawstime/pawstime/domain/user/entity/repository/UserRepository.java
+++ b/src/main/java/com/pawstime/pawstime/domain/user/entity/repository/UserRepository.java
@@ -13,4 +13,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
   @Query("SELECT u FROM User u WHERE u.userId = :userId AND u.isDelete = false")
   User findUserByUserIdQuery(@Param("userId") Long userId);
 
+  User findUserByNick(String nick);
 }

--- a/src/main/java/com/pawstime/pawstime/domain/user/service/read/ReadUserService.java
+++ b/src/main/java/com/pawstime/pawstime/domain/user/service/read/ReadUserService.java
@@ -15,6 +15,10 @@ public class ReadUserService {
     return userRepository.findUserByEmail(email);
   }
 
+  public User findUserByNick(String nick) {
+    return userRepository.findUserByNick(nick);
+  }
+
   public User findUserByUserIdQuery(Long userId) {
     return userRepository.findUserByUserIdQuery(userId);
   }


### PR DESCRIPTION
## 📝 설명 (Description)
사용자가 회원가입 및 닉네임 수정 시 닉네임 중복을 확인하는 기능을 추가했습니다.
이 기능은 사용자가 중복된 닉네임을 입력할 경우 오류를 발생시켜, 닉네임이 고유하도록 관리합니다.

--- 

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:
- [x] 회원가입 시 닉네임 중복 체크: 사용자가 입력한 닉네임이 이미 존재하는지 확인합니다. 중복 시 DuplicateException을 발생시킵니다.
- [x] 닉네임 수정 시 중복 체크: 사용자가 닉네임을 수정할 때, 기존 닉네임과 동일한 경우는 그대로 두고, 중복된 닉네임이 있으면 오류를 발생시킵니다.
- [x] 예외 처리: 중복된 닉네임이 있을 경우 DuplicateException을 발생시키도록 처리했습니다.

---

## 📌 참고 사항 (Additional Notes)

