### PR TITLE
fix: 댓글 조회 기능 수정

### DIFF
--- a/src/main/java/com/pawstime/pawstime/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/pawstime/pawstime/domain/comment/controller/CommentController.java
@@ -73,7 +73,7 @@ public class CommentController {
   }
 
   @Operation(summary = "현재 로그인한 사용자가 작성한 댓글 목록 조회")
-  @GetMapping("/me")
+  @GetMapping("/comments/me")
   public ResponseEntity<ApiResponse<List<GetCommentRespDto>>> getCommentListByUser(
       @RequestParam(defaultValue = "0") int pageNo,
       @RequestParam(defaultValue = "10") int pageSize,

--- a/src/main/java/com/pawstime/pawstime/domain/comment/entity/repository/CommentRepository.java
+++ b/src/main/java/com/pawstime/pawstime/domain/comment/entity/repository/CommentRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -25,5 +26,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
   long countByPost(Post post);
 
-  Page<Comment> findByUser(Pageable pageable, User user);
+  @Query("SELECT c FROM Comment c WHERE c.user = :user AND c.isDelete = false")
+  Page<Comment> findByUser(Pageable pageable, @Param("user") User user);
 }


### PR DESCRIPTION
## 📝 설명 (Description)
댓글 조회 기능에서 URL 오류를 수정하고, 삭제된 댓글(isDelete = true)이 조회되지 않도록 처리했습니다. 

--- 

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:
- [x] 변경사항 1 : 로그인한 사용자의 댓글 조회 API URL 수정 (`"/me"` → `"/comments/me"`)
- [x] 변경사항 2 : @Query 추가하여 로그인한 사용자의 댓글 조회 시 삭제된 댓글(isDelete=true) 제외

---

## 📌 참고 사항 (Additional Notes)
- API 응답 데이터에서 삭제된 댓글이 보이지 않도록 수정되었습니다. 
