### PR TITLE
feat: 비밀번호 찾기 기능 추가 (이메일 + 닉네임으로 사용자 찾기, 비밀번호 변경)

### DIFF
--- a/src/main/java/com/pawstime/pawstime/domain/user/facade/UserFacade.java
+++ b/src/main/java/com/pawstime/pawstime/domain/user/facade/UserFacade.java
@@ -12,6 +12,7 @@ import com.pawstime.pawstime.global.exception.UnauthorizedException;
 import com.pawstime.pawstime.global.jwt.util.JwtUtil;
 import com.pawstime.pawstime.global.security.user.CustomUserDetails;
 import com.pawstime.pawstime.web.api.user.dto.req.LoginUserReqDto;
+import com.pawstime.pawstime.web.api.user.dto.req.ResetPasswordReqDto;
 import com.pawstime.pawstime.web.api.user.dto.req.UpdateNickReqDto;
 import com.pawstime.pawstime.web.api.user.dto.req.UpdatePasswordReqDto;
 import com.pawstime.pawstime.web.api.user.dto.req.UserCreateReqDto;
@@ -188,6 +189,30 @@ public class UserFacade {
     }
 
     String newPassword = encoder.encode(updatePasswordReqDto.newPassword());
+    user.updatePassword(newPassword);
+
+    createUserService.updateUser(user);
+  }
+
+  public Long findUserByEmailAndNick(String email, String nick) {
+    User foundUserByEmail = readUserService.findUserByEmail(email);
+    User foundUserByNick = readUserService.findUserByNick(nick);
+
+    if (foundUserByEmail == null || foundUserByNick == null) {
+      throw new NotFoundException("입력한 이메일과 닉네임에 일치하는 계정이 존재하지 않습니다.");
+    }
+
+    if (!foundUserByEmail.getUserId().equals(foundUserByNick.getUserId())) {
+      throw new NotFoundException("입력한 이메일과 닉네임에 일치하는 계정이 존재하지 않습니다.");
+    }
+
+    return foundUserByEmail.getUserId();
+  }
+
+  public void resetPassword(Long userId, ResetPasswordReqDto resetPasswordReqDto) {
+    User user = readUserService.findUserByUserIdQuery(userId);
+
+    String newPassword = encoder.encode(resetPasswordReqDto.newPassword());
     user.updatePassword(newPassword);
 
     createUserService.updateUser(user);

--- a/src/main/java/com/pawstime/pawstime/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/pawstime/pawstime/global/config/security/SecurityConfig.java
@@ -51,7 +51,7 @@ public class SecurityConfig {
   // 모든 사용자에게 접근을 허용하는 경로
   private static final String[] PUBLIC_ALL = {
     "/users", "/users/login", "/users/{userId}", "/posts/{postId}/thumbnail",
-    "/posts/images/random", "/info/**"
+    "/posts/images/random", "/info/**", "users/password-reset", "users/{userId}/password-reset"
   };
 
   @Bean

--- a/src/main/java/com/pawstime/pawstime/web/api/user/UserController.java
+++ b/src/main/java/com/pawstime/pawstime/web/api/user/UserController.java
@@ -1,27 +1,26 @@
 package com.pawstime.pawstime.web.api.user;
 
-import com.pawstime.pawstime.domain.user.entity.User;
 import com.pawstime.pawstime.domain.user.facade.UserFacade;
 import com.pawstime.pawstime.global.common.ApiResponse;
 import com.pawstime.pawstime.global.enums.Status;
-import com.pawstime.pawstime.global.exception.CustomException;
 import com.pawstime.pawstime.web.api.user.dto.req.LoginUserReqDto;
 import com.pawstime.pawstime.web.api.user.dto.req.UpdateNickReqDto;
 import com.pawstime.pawstime.web.api.user.dto.req.UpdatePasswordReqDto;
 import com.pawstime.pawstime.web.api.user.dto.req.UserCreateReqDto;
+import com.pawstime.pawstime.web.api.user.dto.req.ResetPasswordReqDto;
 import com.pawstime.pawstime.web.api.user.dto.resp.GetUserRespDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
+@Slf4j
 @Tag(name = "USER API", description = "유저 API")
 @RestController
 @RequiredArgsConstructor
@@ -92,6 +91,26 @@ public class UserController {
   ) {
     userFacade.updatePassword(updatePasswordReqDto, httpServletRequest);
     userFacade.logout(authentication, httpServletRequest);
+    return ApiResponse.generateResp(Status.UPDATE, "비밀번호 수정이 완료되었습니다.", null);
+  }
+
+  @Operation(summary = "비밀번호 찾기 1단계 (이메일과 닉네임으로 사용자 찾기)")
+  @GetMapping("/password-reset")
+  public ResponseEntity<ApiResponse<Long>> findUserByEmailAndNick(
+      @RequestParam String email, @RequestParam String nick
+  ) {
+    Long userId = userFacade.findUserByEmailAndNick(email, nick);
+
+    return ApiResponse.generateResp(Status.SUCCESS, "입력한 정보와 일치하는 계정이 존재합니다.", userId);
+  }
+
+  @Operation(summary = "비밀번호 찾기 2단계 (비밀번호 변경)")
+  @PutMapping("/{userId}/password-reset")
+  public ResponseEntity<ApiResponse<Void>> resetPassword(
+      @PathVariable Long userId, @Valid @RequestBody ResetPasswordReqDto resetPasswordReqDto
+  ) {
+    userFacade.resetPassword(userId, resetPasswordReqDto);
+
     return ApiResponse.generateResp(Status.UPDATE, "비밀번호 수정이 완료되었습니다.", null);
   }
 }

--- a/src/main/java/com/pawstime/pawstime/web/api/user/dto/req/ResetPasswordReqDto.java
+++ b/src/main/java/com/pawstime/pawstime/web/api/user/dto/req/ResetPasswordReqDto.java
@@ -1,0 +1,17 @@
+package com.pawstime.pawstime.web.api.user.dto.req;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record ResetPasswordReqDto(
+    @Schema(description = "변경할 비밀번호", example = "Qwer12345^^")
+    @NotBlank(message = "변경할 비밀번호를 입력하세요.")
+    @Size(min = 8, max = 20, message = "새로운 비밀번호는 8자 이상 20자 이하만 가능합니다.")
+    @Pattern(regexp = "^(?=.*[A-Z])(?=.*[0-9])(?=.*[a-z])(?=.*[!@#$%^&*()-+=]).*$",
+        message = "새로운 비밀번호는 대/소문자, 숫자, 특수문자를 포함해야 합니다.")
+    String newPassword
+) {
+
+}


### PR DESCRIPTION
## 📝 설명 (Description)
비밀번호 찾기 기능을 구현했습니다. 사용자가 이메일과 닉네임을 입력하여 일치하는 계정을 찾은 후, 새로운 비밀번호를 입력해 비밀번호를 변경할 수 있도록 했습니다. 
이 기능을 통해 사용자는 비밀번호를 잊어버렸을 때, 이메일과 닉네임만으로 비밀번호를 재설정할 수 있습니다.

--- 

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:
- [x] 비밀번호 찾기 1단계 (이메일과 닉네임으로 사용자 찾기): 사용자가 이메일과 닉네임을 입력하여 해당 계정을 찾고, 일치하는 계정이 있으면 사용자 ID를 반환합니다.
- [x] 비밀번호 찾기 2단계 (비밀번호 변경): 사용자가 제공한 사용자 ID와 새로운 비밀번호를 받아 비밀번호를 변경합니다.
- [x] DTO 유효성 검사: 새로운 비밀번호의 유효성 검사를 추가하여, 비밀번호가 안전한 형식(대/소문자, 숫자, 특수문자 포함)인지 확인합니다.
- [x] 예외 처리: 이메일과 닉네임이 일치하는 계정이 없을 경우 NotFoundException을 발생시켜 오류를 처리합니다.

---

## 📌 참고 사항 (Additional Notes)
비밀번호 변경 기능은 보안상 중요한 기능이므로, 추후 이메일 인증 등의 기능을 추가하여 보안을 강화할 수 있습니다.
